### PR TITLE
Fix the repository URL in `pubspec.yaml`

### DIFF
--- a/pkgs/args/CHANGELOG.md
+++ b/pkgs/args/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1-wip
+
+* Fix the reporitory URL in `pubspec.yaml`.
+
 ## 2.6.0
 
 * Added source argument when throwing a `ArgParserException`.

--- a/pkgs/args/pubspec.yaml
+++ b/pkgs/args/pubspec.yaml
@@ -3,7 +3,7 @@ version: 2.6.0
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.
-repository: https://github.com/dart-lang/core/main/pkgs/args
+repository: https://github.com/dart-lang/core/tree/main/pkgs/args
 
 topics:
   - cli

--- a/pkgs/args/pubspec.yaml
+++ b/pkgs/args/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.6.0
+version: 2.6.1-wip
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.


### PR DESCRIPTION
The branch name `main` must be preceded by `tree`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
