### PR TITLE
Add function to retrieve actual input values for command options by name.

### DIFF
--- a/pkgs/args/CHANGELOG.md
+++ b/pkgs/args/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.6.1-wip
 
 * Fix the reporitory URL in `pubspec.yaml`.
+* Add function to retrieve actual input values for command options by name.
 
 ## 2.6.0
 

--- a/pkgs/args/lib/src/arg_results.dart
+++ b/pkgs/args/lib/src/arg_results.dart
@@ -13,11 +13,12 @@ import 'arg_parser.dart';
 ArgResults newArgResults(
     ArgParser parser,
     Map<String, dynamic> parsed,
+    Map<String, String> actual,
     String? name,
     ArgResults? command,
     List<String> rest,
     List<String> arguments) {
-  return ArgResults._(parser, parsed, name, command, rest, arguments);
+  return ArgResults._(parser, parsed, actual, name, command, rest, arguments);
 }
 
 /// The results of parsing a series of command line arguments using
@@ -31,6 +32,9 @@ class ArgResults {
 
   /// The option values that were parsed from arguments.
   final Map<String, dynamic> _parsed;
+
+  /// The actual values that were parsed from arguments.
+  final Map<String, String> _actual;
 
   /// The name of the command for which these options are parsed, or `null` if
   /// these are the top-level results.
@@ -52,8 +56,8 @@ class ArgResults {
   /// The original arguments that were parsed.
   final List<String> arguments;
 
-  ArgResults._(this._parser, this._parsed, this.name, this.command,
-      List<String> rest, List<String> arguments)
+  ArgResults._(this._parser, this._parsed, this._actual, this.name,
+      this.command, List<String> rest, List<String> arguments)
       : rest = UnmodifiableListView(rest),
         arguments = UnmodifiableListView(arguments);
 
@@ -132,6 +136,18 @@ class ArgResults {
     });
 
     return result;
+  }
+
+  /// Returns the actual value of the command-line option named [name].
+  /// Returns `null` if the option was not provided.
+  ///
+  /// [name] must be a valid option name in the parser.
+  String? actual(String name) {
+    if (_actual.containsKey(name)) {
+      return _actual[name];
+    } else {
+      return null;
+    }
   }
 
   /// Returns `true` if the option with [name] was parsed from an actual

--- a/pkgs/args/test/parse_test.dart
+++ b/pkgs/args/test/parse_test.dart
@@ -730,6 +730,52 @@ void main() {
       });
     });
 
+    group('actual()', () {
+      test('returns value if present', () {
+        var parser = ArgParser();
+        parser.addFlag('verbose');
+        parser.addOption('mode');
+        parser.addMultiOption('define');
+
+        var args = parser.parse(['--verbose', '--mode=release', '--define=1']);
+        expect(args.actual('verbose'), '--verbose');
+        expect(args.actual('mode'), '--mode');
+        expect(args.actual('define'), '--define');
+      });
+
+      test('returns null if missing', () {
+        var parser = ArgParser();
+        parser.addFlag('a', defaultsTo: true);
+        parser.addOption('b', defaultsTo: 'c');
+        parser.addMultiOption('d', defaultsTo: ['e']);
+
+        var args = parser.parse([]);
+        expect(args.actual('a'), isNull);
+        expect(args.actual('b'), isNull);
+        expect(args.actual('d'), isNull);
+      });
+
+      test('can match by alias', () {
+        var parser = ArgParser()..addFlag('verbose', abbr: 'v');
+        var results = parser.parse(['-v']);
+        expect(results.actual('verbose'), '-v');
+      });
+
+      test('can be negated by alias', () {
+        var parser = ArgParser()
+          ..addFlag('a', aliases: ['b'], defaultsTo: true, negatable: true);
+        var results = parser.parse(['--no-b']);
+        expect(results.actual('a'), '--no-b');
+      });
+
+      // abbr test
+      test('can match by abbreviation', () {
+        var parser = ArgParser()..addFlag('a', abbr: 'b');
+        var results = parser.parse(['-b']);
+        expect(results.actual('a'), '-b');
+      });
+    });
+
     group('remaining args', () {
       test('stops parsing args when a non-option-like arg is encountered', () {
         var parser = ArgParser();


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>

---

Add function to retrieve actual input values for command options by name.
Continuation of https://github.com/dart-lang/args/pull/284

Motivation to add this.


```dart
import 'package:args/args.dart';

void main(List<String> args) {
  var parser = ArgParser();
  parser.addOption('size', abbr: 's', defaultsTo: '20');

  var results = parser.parse(args);

  var size = int.tryParse(results.option('size')!);

  if (size == null) {
    print('Could not parse the ${results.actual('size')} as an integer');
  } else {
    print('The size is $size');
  }
}
```
```sh
$ dart sample.dart --size aa
Could not parse the --size as an integer
$ dart sample.dart -s aa
Could not parse the -s as an integer
```

