### PR TITLE
os_detect: bump lints and SDK versions

### DIFF
--- a/.github/workflows/os_detect.yaml
+++ b/.github/workflows/os_detect.yaml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest, windows-latest, macos-latest]
-        sdk: [3.0.0, dev]
+        sdk: [3.5, dev]
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672

--- a/pkgs/args/analysis_options.yaml
+++ b/pkgs/args/analysis_options.yaml
@@ -10,5 +10,3 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
-    - unnecessary_await_in_return

--- a/pkgs/args/pubspec.yaml
+++ b/pkgs/args/pubspec.yaml
@@ -13,4 +13,4 @@ environment:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
-  test: ^1.16.0
+  test: ^1.16.6

--- a/pkgs/async/analysis_options.yaml
+++ b/pkgs/async/analysis_options.yaml
@@ -18,4 +18,3 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs

--- a/pkgs/collection/analysis_options.yaml
+++ b/pkgs/collection/analysis_options.yaml
@@ -12,5 +12,4 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - unnecessary_await_in_return

--- a/pkgs/collection/pubspec.yaml
+++ b/pkgs/collection/pubspec.yaml
@@ -13,4 +13,4 @@ environment:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
-  test: ^1.16.0
+  test: ^1.16.6

--- a/pkgs/convert/analysis_options.yaml
+++ b/pkgs/convert/analysis_options.yaml
@@ -17,7 +17,6 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - unnecessary_await_in_return

--- a/pkgs/crypto/analysis_options.yaml
+++ b/pkgs/crypto/analysis_options.yaml
@@ -10,4 +10,3 @@ linter:
   rules:
     - avoid_unused_constructor_parameters
     - cancel_subscriptions
-    - package_api_docs

--- a/pkgs/fixnum/analysis_options.yaml
+++ b/pkgs/fixnum/analysis_options.yaml
@@ -14,7 +14,6 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - unnecessary_raw_strings

--- a/pkgs/logging/analysis_options.yaml
+++ b/pkgs/logging/analysis_options.yaml
@@ -20,7 +20,6 @@ linter:
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString
-    - package_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_locals

--- a/pkgs/logging/pubspec.yaml
+++ b/pkgs/logging/pubspec.yaml
@@ -14,4 +14,4 @@ environment:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
-  test: ^1.16.0
+  test: ^1.16.6

--- a/pkgs/os_detect/CHANGELOG.md
+++ b/pkgs/os_detect/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3-wip
+
+- Require Dart 3.5
+
 ## 2.0.2
 
 - Require Dart 3.0

--- a/pkgs/os_detect/analysis_options.yaml
+++ b/pkgs/os_detect/analysis_options.yaml
@@ -20,7 +20,6 @@ linter:
   - missing_whitespace_between_adjacent_strings
   - no_adjacent_strings_in_list
   - no_runtimeType_toString
-  - package_api_docs
   - prefer_const_declarations
   - use_raw_strings
 

--- a/pkgs/os_detect/bin/os_detect.dart
+++ b/pkgs/os_detect/bin/os_detect.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Prints the operating system detected by the current compilation environment.
-library pkg.os_detect.run;
+library;
 
 import 'package:os_detect/os_detect.dart' as os_detect;
 

--- a/pkgs/os_detect/lib/os_detect.dart
+++ b/pkgs/os_detect/lib/os_detect.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Information about the current operating system.
-library pkg.os_detect;
+library;
 
 import 'src/os_override.dart';
 

--- a/pkgs/os_detect/pubspec.yaml
+++ b/pkgs/os_detect/pubspec.yaml
@@ -1,14 +1,14 @@
 name: os_detect
-version: 2.0.2
+version: 2.0.3-wip
 description: Platform independent OS detection.
 repository: https://github.com/dart-lang/core/tree/main/pkgs/os_detect
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   meta: ^1.9.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^2.0.0
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.24.0

--- a/pkgs/path/analysis_options.yaml
+++ b/pkgs/path/analysis_options.yaml
@@ -9,7 +9,6 @@ linter:
     - join_return_with_assignment
     - missing_whitespace_between_adjacent_strings
     - no_runtimeType_toString
-    - package_api_docs
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_locals

--- a/pkgs/platform/example/pubspec.yaml
+++ b/pkgs/platform/example/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^5.0.0

--- a/pkgs/typed_data/analysis_options.yaml
+++ b/pkgs/typed_data/analysis_options.yaml
@@ -10,4 +10,3 @@ linter:
     - avoid_unused_constructor_parameters
     - cancel_subscriptions
     - no_adjacent_strings_in_list
-    - package_api_docs


### PR DESCRIPTION
...and other cleanup across the board

- drop deprecated lints
- drop redundant lints
- tiny bump to min test version using --tighten pub command
