### PR TITLE
Introduce `IterableMapEntryExtension` for use with `Map.entries`.

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.19.1-wip
+- Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
+  `Map.entries`.
+
 ## 1.19.1
 
 - Move to `dart-lang/core` monorepo.

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -914,6 +914,33 @@ extension IterableIterableExtension<T> on Iterable<Iterable<T>> {
       };
 }
 
+/// Extension on iterables of [MapEntry].
+///
+/// An [Iterable<MapEntry>] is obtained using [Map.entries], these extensions
+/// make it easy to work on a [Map] as a list of pairs.
+extension IterableMapEntryExtension<K, V> on Iterable<MapEntry<K, V>> {
+  /// Creates a new lazy [Iterable] with all elements whose [MapEntry.key]
+  /// satisfy the predicate [test].
+  Iterable<MapEntry<K, V>> whereKey(bool Function(K) test) =>
+      where((e) => test(e.key));
+
+  /// Creates a new lazy [Iterable] with all elements whose [MapEntry.value]
+  /// satisfy the predicate [test].
+  Iterable<MapEntry<K, V>> whereValue(bool Function(V) test) =>
+      where((e) => test(e.value));
+
+  /// Create an new lazy [Iterable] with [MapEntry.key] from all elements.
+  Iterable<K> get keys => map((e) => e.key);
+
+  /// Create an new lazy [Iterable] with [MapEntry.value] from all elements.
+  Iterable<V> get values => map((e) => e.value);
+
+  /// Create a [Map] from all elements.
+  ///
+  /// This is a short-hand for [Map.fromEntries].
+  Map<K, V> toMap() => Map.fromEntries(this);
+}
+
 /// Extensions that apply to iterables of [Comparable] elements.
 ///
 /// These operations can assume that the elements have a natural ordering,

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -916,29 +916,39 @@ extension IterableIterableExtension<T> on Iterable<Iterable<T>> {
 
 /// Extension on iterables of [MapEntry].
 ///
-/// An [Iterable<MapEntry>] is obtained using [Map.entries], these extensions
-/// make it easy to work on a [Map] as a list of pairs.
+/// An [Iterable<MapEntry>] is obtained using [Map.entries]. These extensions
+/// facilitates working directly on the entries of a [Map].
 extension IterableMapEntryExtension<K, V> on Iterable<MapEntry<K, V>> {
-  /// Creates a new lazy [Iterable] with all elements whose [MapEntry.key]
-  /// satisfy the predicate [test].
+  /// The elements whose [MapEntry.key] values satisfy [test].
+  ///
+  /// The resulting iterable is lazily computing its elements
+  /// based on the elements this iterable.
   Iterable<MapEntry<K, V>> whereKey(bool Function(K) test) =>
       where((e) => test(e.key));
 
-  /// Creates a new lazy [Iterable] with all elements whose [MapEntry.value]
-  /// satisfy the predicate [test].
+  /// The elements whose [MapEntry.value] values satisfy [test].
+  ///
+  /// The resulting iterable is lazily computing its elements
+  /// based on the elements this iterable.
   Iterable<MapEntry<K, V>> whereValue(bool Function(V) test) =>
       where((e) => test(e.value));
 
-  /// Create an new lazy [Iterable] with [MapEntry.key] from all elements.
+  /// A new lazy [Iterable] of the [MapEntry.key]s of these entries.
+  ///
+  /// Do not use this getter as `map.entries.keys`, just use `map.keys`
+  /// directly.
   Iterable<K> get keys => map((e) => e.key);
 
-  /// Create an new lazy [Iterable] with [MapEntry.value] from all elements.
+  /// A new lazy [Iterable] of the [MapEntry.value]s of these entries.
+  ///
+  /// Do not use this getter as `map.entries.values`, just use `map.values`
+  /// directly.
   Iterable<V> get values => map((e) => e.value);
 
-  /// Create a [Map] from all elements.
+  /// Create a [Map<K, V>] from all elements.
   ///
   /// This is a short-hand for [Map.fromEntries].
-  Map<K, V> toMap() => Map.fromEntries(this);
+  Map<K, V> toMap() => Map<K, V>.fromEntries(this);
 }
 
 /// Extensions that apply to iterables of [Comparable] elements.

--- a/pkgs/collection/pubspec.yaml
+++ b/pkgs/collection/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.19.1
+version: 1.19.1-wip
 description: >-
   Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/core/tree/main/pkgs/collection

--- a/pkgs/collection/test/extensions_test.dart
+++ b/pkgs/collection/test/extensions_test.dart
@@ -1122,6 +1122,87 @@ void main() {
         });
       });
     });
+    group('of MapEntry', () {
+      group('.whereKey', () {
+        test('empty', () {
+          expect(<String, int>{}.entries.whereKey(unreachable), isEmpty);
+        });
+        test('single', () {
+          expect({'a': 1}.entries.whereKey((k) => k == 'a').toMap(), {'a': 1});
+          expect({'a': 1}.entries.whereKey((k) => k == 'b').toMap(), isEmpty);
+        });
+        test('multiple', () {
+          expect(
+            {'a': 1, 'b': 2}.entries.whereKey((k) => k == 'a').toMap(),
+            {'a': 1},
+          );
+          expect(
+            {'a': 1, 'b': 2}.entries.whereKey((k) => k == 'b').toMap(),
+            {'b': 2},
+          );
+          expect(
+            {'a': 1, 'b': 2}.entries.whereKey((k) => k != 'c').toMap(),
+            {'a': 1, 'b': 2},
+          );
+        });
+      });
+      group('.whereValue', () {
+        test('empty', () {
+          expect(<String, int>{}.entries.whereValue(unreachable), isEmpty);
+        });
+        test('single', () {
+          expect({'a': 1}.entries.whereValue((v) => v == 1).toMap(), {'a': 1});
+          expect({'a': 1}.entries.whereValue((v) => v == 2).toMap(), isEmpty);
+        });
+        test('multiple', () {
+          expect(
+            {'a': 1, 'b': 2}.entries.whereValue((v) => v == 1).toMap(),
+            {'a': 1},
+          );
+          expect(
+            {'a': 1, 'b': 2}.entries.whereValue((v) => v == 2).toMap(),
+            {'b': 2},
+          );
+          expect(
+            {'a': 1, 'b': 2}.entries.whereValue((v) => v != 3).toMap(),
+            {'a': 1, 'b': 2},
+          );
+        });
+      });
+      group('.keys', () {
+        test('empty', () {
+          expect(<String, int>{}.entries.keys, isEmpty);
+        });
+        test('single', () {
+          expect({'a': 1}.entries.keys, ['a']);
+        });
+        test('multiple', () {
+          expect({'a': 1, 'b': 2}.entries.keys, ['a', 'b']);
+        });
+      });
+      group('.values', () {
+        test('empty', () {
+          expect(<String, int>{}.entries.values, isEmpty);
+        });
+        test('single', () {
+          expect({'a': 1}.entries.values, [1]);
+        });
+        test('multiple', () {
+          expect({'a': 1, 'b': 2}.entries.values, [1, 2]);
+        });
+      });
+      group('.toMap', () {
+        test('empty', () {
+          expect(<String, int>{}.entries.toMap(), <String, int>{});
+        });
+        test('single', () {
+          expect({'a': 1}.entries.toMap(), {'a': 1});
+        });
+        test('multiple', () {
+          expect({'a': 1, 'b': 2}.entries.toMap(), {'a': 1, 'b': 2});
+        });
+      });
+    });
     group('of comparable', () {
       group('.min', () {
         test('empty', () {

--- a/pkgs/collection/test/extensions_test.dart
+++ b/pkgs/collection/test/extensions_test.dart
@@ -1125,81 +1125,174 @@ void main() {
     group('of MapEntry', () {
       group('.whereKey', () {
         test('empty', () {
-          expect(<String, int>{}.entries.whereKey(unreachable), isEmpty);
+          expect(
+            iterable(<MapEntry<String, int>>[]).whereKey(unreachable),
+            isEmpty,
+          );
         });
         test('single', () {
-          expect({'a': 1}.entries.whereKey((k) => k == 'a').toMap(), {'a': 1});
-          expect({'a': 1}.entries.whereKey((k) => k == 'b').toMap(), isEmpty);
+          expect(
+            iterable([const MapEntry('a', 1)]).whereKey((k) => k == 'a'),
+            [const MapEntry('a', 1)],
+          );
+          expect(
+            iterable([const MapEntry('a', 1)]).whereKey((k) => k == 'b'),
+            isEmpty,
+          );
         });
         test('multiple', () {
           expect(
-            {'a': 1, 'b': 2}.entries.whereKey((k) => k == 'a').toMap(),
-            {'a': 1},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereKey((k) => k == 'a'),
+            [const MapEntry('a', 1)],
           );
           expect(
-            {'a': 1, 'b': 2}.entries.whereKey((k) => k == 'b').toMap(),
-            {'b': 2},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereKey((k) => k == 'b'),
+            [const MapEntry('b', 2)],
           );
           expect(
-            {'a': 1, 'b': 2}.entries.whereKey((k) => k != 'c').toMap(),
-            {'a': 1, 'b': 2},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereKey((k) => k != 'c'),
+            [const MapEntry('a', 1), const MapEntry('b', 2)],
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('a', 3),
+            ]).whereKey((k) => k == 'a'),
+            [const MapEntry('a', 1), const MapEntry('a', 3)],
           );
         });
       });
       group('.whereValue', () {
         test('empty', () {
-          expect(<String, int>{}.entries.whereValue(unreachable), isEmpty);
+          expect(
+            iterable(<MapEntry<String, int>>[]).whereValue(unreachable),
+            isEmpty,
+          );
         });
         test('single', () {
-          expect({'a': 1}.entries.whereValue((v) => v == 1).toMap(), {'a': 1});
-          expect({'a': 1}.entries.whereValue((v) => v == 2).toMap(), isEmpty);
+          expect(
+            iterable([const MapEntry('a', 1)]).whereValue((v) => v == 1),
+            [const MapEntry('a', 1)],
+          );
+          expect(
+            iterable([const MapEntry('a', 1)]).whereValue((v) => v == 2),
+            isEmpty,
+          );
         });
         test('multiple', () {
           expect(
-            {'a': 1, 'b': 2}.entries.whereValue((v) => v == 1).toMap(),
-            {'a': 1},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereValue((v) => v == 1),
+            [const MapEntry('a', 1)],
           );
           expect(
-            {'a': 1, 'b': 2}.entries.whereValue((v) => v == 2).toMap(),
-            {'b': 2},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereValue((v) => v == 2),
+            [const MapEntry('b', 2)],
           );
           expect(
-            {'a': 1, 'b': 2}.entries.whereValue((v) => v != 3).toMap(),
-            {'a': 1, 'b': 2},
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+            ]).whereValue((v) => v != 3),
+            [const MapEntry('a', 1), const MapEntry('b', 2)],
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('c', 1),
+            ]).whereValue((v) => v == 1),
+            [const MapEntry('a', 1), const MapEntry('c', 1)],
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('a', 1),
+            ]).whereValue((v) => v == 1),
+            [const MapEntry('a', 1), const MapEntry('a', 1)],
           );
         });
       });
       group('.keys', () {
         test('empty', () {
-          expect(<String, int>{}.entries.keys, isEmpty);
+          expect(iterable(<MapEntry<String, int>>[]).keys, isEmpty);
         });
         test('single', () {
-          expect({'a': 1}.entries.keys, ['a']);
+          expect(iterable([const MapEntry('a', 1)]).keys, ['a']);
         });
         test('multiple', () {
-          expect({'a': 1, 'b': 2}.entries.keys, ['a', 'b']);
+          expect(
+            iterable([const MapEntry('a', 1), const MapEntry('b', 2)]).keys,
+            ['a', 'b'],
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('a', 3),
+            ]).keys,
+            ['a', 'b', 'a'],
+          );
         });
       });
       group('.values', () {
         test('empty', () {
-          expect(<String, int>{}.entries.values, isEmpty);
+          expect(iterable(<MapEntry<String, int>>[]).values, isEmpty);
         });
         test('single', () {
-          expect({'a': 1}.entries.values, [1]);
+          expect(iterable([const MapEntry('a', 1)]).values, [1]);
         });
         test('multiple', () {
-          expect({'a': 1, 'b': 2}.entries.values, [1, 2]);
+          expect(
+            iterable([const MapEntry('a', 1), const MapEntry('b', 2)]).values,
+            [1, 2],
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('a', 3),
+            ]).values,
+            [1, 2, 3],
+          );
         });
       });
       group('.toMap', () {
         test('empty', () {
-          expect(<String, int>{}.entries.toMap(), <String, int>{});
+          expect(iterable(<MapEntry<String, int>>[]).toMap(), <String, int>{});
         });
         test('single', () {
-          expect({'a': 1}.entries.toMap(), {'a': 1});
+          expect(iterable([const MapEntry('a', 1)]).toMap(), {'a': 1});
         });
         test('multiple', () {
-          expect({'a': 1, 'b': 2}.entries.toMap(), {'a': 1, 'b': 2});
+          expect(
+            iterable([const MapEntry('a', 1), const MapEntry('b', 2)]).toMap(),
+            {'a': 1, 'b': 2},
+          );
+          expect(
+            iterable([
+              const MapEntry('a', 1),
+              const MapEntry('b', 2),
+              const MapEntry('a', 3),
+            ]).toMap(),
+            {'b': 2, 'a': 3},
+          );
         });
       });
     });


### PR DESCRIPTION
These utilities could often be useful when working with maps. We could also put this into a different utility package.

**Example**:
```dart
final myMap = {
  'foo': 42,
  'bar': -1,
  'foobar': 21,
};

// myMap without negative values
myMap.entries.whereValue((v) => v >= 0).toMap();

// myMap, but only keys that start with 'foo'
myMap.entries.whereKey((k) => k.startsWith('foo')).toMap();
```

------

I'm tempted to also suggest:
```dart
  Iterable<T> mapKeyValue<T>(T Function(K, V) convert) =>
      map((e) => convert(e.key, e.value));
```

But the name is a bit long. `mapKV` is lovely short, but probably too ugly.
When doing `.map` over `Iterable<MapEntry>` you generally don't want to write `.map((entry) => entry.key`.