### PR TITLE
add a basic benchmark for DeepCollectionEquality

### DIFF
--- a/pkgs/collection/.gitignore
+++ b/pkgs/collection/.gitignore
@@ -8,3 +8,4 @@ build/
 packages
 .packages
 pubspec.lock
+benchmark/*.exe

--- a/pkgs/collection/benchmark/deep_collection_equality.dart
+++ b/pkgs/collection/benchmark/deep_collection_equality.dart
@@ -22,8 +22,8 @@ class DeepCollectionEqualityBase extends BenchmarkBase {
         super('DeepCollectionQuality${unordered ? 'Unordered' : ''}.$function');
 }
 
-class DeepCollectionEqualityEqualsBenchmark extends DeepCollectionEqualityBase {
-  DeepCollectionEqualityEqualsBenchmark(bool unordered)
+class DeepCollectionEqualityHashBenchmark extends DeepCollectionEqualityBase {
+  DeepCollectionEqualityHashBenchmark(bool unordered)
       : super(unordered, 'hash');
 
   @override
@@ -34,8 +34,8 @@ class DeepCollectionEqualityEqualsBenchmark extends DeepCollectionEqualityBase {
   static int hash = 0;
 }
 
-class DeepCollectionEqualityHashBenchmark extends DeepCollectionEqualityBase {
-  DeepCollectionEqualityHashBenchmark(bool unordered)
+class DeepCollectionEqualityEqualsBenchmark extends DeepCollectionEqualityBase {
+  DeepCollectionEqualityEqualsBenchmark(bool unordered)
       : super(unordered, 'equals');
 
   @override

--- a/pkgs/collection/benchmark/deep_collection_equality.dart
+++ b/pkgs/collection/benchmark/deep_collection_equality.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:collection/collection.dart';
+
+void main() {
+  for (var unordered in [true, false]) {
+    DeepCollectionEqualityEqualsBenchmark(unordered).report();
+    DeepCollectionEqualityHashBenchmark(unordered).report();
+  }
+}
+
+class DeepCollectionEqualityBase extends BenchmarkBase {
+  final DeepCollectionEquality equality;
+
+  DeepCollectionEqualityBase(bool unordered, String function)
+      : equality = unordered
+            ? const DeepCollectionEquality.unordered()
+            : const DeepCollectionEquality(),
+        super('DeepCollectionQuality${unordered ? 'Unordered' : ''}.$function');
+}
+
+class DeepCollectionEqualityEqualsBenchmark extends DeepCollectionEqualityBase {
+  DeepCollectionEqualityEqualsBenchmark(bool unordered)
+      : super(unordered, 'hash');
+
+  @override
+  void run() {
+    hash = equality.hash(mapA);
+  }
+
+  static int hash = 0;
+}
+
+class DeepCollectionEqualityHashBenchmark extends DeepCollectionEqualityBase {
+  DeepCollectionEqualityHashBenchmark(bool unordered)
+      : super(unordered, 'equals');
+
+  @override
+  void run() {
+    equals = equality.equals(mapA, mapB);
+  }
+
+  static bool equals = false;
+}
+
+final mapA = {
+  for (var i = 0; i < 100; i++)
+    {
+      [
+        for (var j = i; j < i + 10; j++) j,
+      ]: i.isEven ? i : '$i',
+    }
+};
+
+final mapB = {
+  for (var i = 0; i < 100; i++)
+    {
+      [
+        for (var j = i; j < i + 10; j++) j,
+      ]: i.isEven ? i : '$i',
+    }
+};

--- a/pkgs/collection/pubspec.yaml
+++ b/pkgs/collection/pubspec.yaml
@@ -12,5 +12,6 @@ environment:
   sdk: ^3.4.0
 
 dev_dependencies:
+  benchmark_harness: ^2.3.1
   dart_flutter_team_lints: ^3.0.0
   test: ^1.16.6


### PR DESCRIPTION
I wanted to check the performance impact of using `.entries` instead of `.keys` followed by a lookup, so I wrote this.

Will send out that PR separately - spoiler alert we might not want to land it 🤣 .