### PR TITLE
Use `values` iterator  and `update` in map equality/hash

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 1.19.1-wip
+
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
   `Map.entries`.
+- Use `entries` and `update` in map equality implementations.
+  - Speeds up all equality checks.
+  - Speeds up implementations for maps with slow lookup, at a slight cost for
+    other implementations.
 
 ## 1.19.1
 

--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
   `Map.entries`.
-- Use `entries` and `update` in map equality implementations.
-  - Speeds up all equality checks.
-  - Speeds up implementations for maps with slow lookup, at a slight cost for
-    other implementations.
+- Optimize equality and hash code for maps by using `update` and a `values`
+  iterator to avoid extra lookups.
 
 ## 1.19.1
 

--- a/pkgs/collection/lib/src/equality.dart
+++ b/pkgs/collection/lib/src/equality.dart
@@ -329,14 +329,14 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
     for (var key in map1.keys) {
       var value = (values1..moveNext()).current;
       var entry = _MapEntry(this, key, value);
-      equalElementCounts.update(entry, (i) => i + 1, ifAbsent: () => 1);
+      equalElementCounts.update(entry, _addOne, ifAbsent: _one);
     }
     final values2 = map2.values.iterator;
     for (var key in map2.keys) {
       var value = (values2..moveNext()).current;
       var entry = _MapEntry(this, key, value);
-      var count =
-          equalElementCounts.update(entry, (i) => i - 1, ifAbsent: () => -1);
+      var count = equalElementCounts.update(entry, _subtractOne,
+          ifAbsent: _negativeOne);
       if (count < 0) return false;
     }
     return true;
@@ -494,3 +494,8 @@ class CaseInsensitiveEquality implements Equality<String> {
   @override
   bool isValidKey(Object? object) => object is String;
 }
+
+int _addOne(int i) => i + 1;
+int _subtractOne(int i) => i - 1;
+int _one() => 1;
+int _negativeOne() => -1;

--- a/pkgs/collection/lib/src/equality.dart
+++ b/pkgs/collection/lib/src/equality.dart
@@ -325,11 +325,15 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
     var length = map1.length;
     if (length != map2.length) return false;
     Map<_MapEntry, int> equalElementCounts = HashMap();
-    for (var MapEntry(:key, :value) in map1.entries) {
+    var values1 = map1.values.iterator;
+    for (var key in map1.keys) {
+      var value = (values1..moveNext()).current;
       var entry = _MapEntry(this, key, value);
       equalElementCounts.update(entry, (i) => i + 1, ifAbsent: () => 1);
     }
-    for (var MapEntry(:key, :value) in map2.entries) {
+    final values2 = map2.values.iterator;
+    for (var key in map2.keys) {
+      var value = (values2..moveNext()).current;
       var entry = _MapEntry(this, key, value);
       var count =
           equalElementCounts.update(entry, (i) => i - 1, ifAbsent: () => -1);
@@ -342,7 +346,9 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
   int hash(Map<K, V>? map) {
     if (map == null) return null.hashCode;
     var hash = 0;
-    for (var MapEntry(:key, :value) in map.entries) {
+    var values = map.values.iterator;
+    for (var key in map.keys) {
+      var value = (values..moveNext()).current;
       var keyHash = _keyEquality.hash(key);
       var valueHash = _valueEquality.hash(value);
       hash = (hash + 3 * keyHash + 7 * valueHash) & _hashMask;

--- a/pkgs/collection/lib/src/equality.dart
+++ b/pkgs/collection/lib/src/equality.dart
@@ -325,16 +325,15 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
     var length = map1.length;
     if (length != map2.length) return false;
     Map<_MapEntry, int> equalElementCounts = HashMap();
-    for (var key in map1.keys) {
-      var entry = _MapEntry(this, key, map1[key]);
-      var count = equalElementCounts[entry] ?? 0;
-      equalElementCounts[entry] = count + 1;
+    for (var MapEntry(:key, :value) in map1.entries) {
+      var entry = _MapEntry(this, key, value);
+      equalElementCounts.update(entry, (i) => i + 1, ifAbsent: () => 1);
     }
-    for (var key in map2.keys) {
-      var entry = _MapEntry(this, key, map2[key]);
-      var count = equalElementCounts[entry];
-      if (count == null || count == 0) return false;
-      equalElementCounts[entry] = count - 1;
+    for (var MapEntry(:key, :value) in map2.entries) {
+      var entry = _MapEntry(this, key, value);
+      var count =
+          equalElementCounts.update(entry, (i) => i - 1, ifAbsent: () => -1);
+      if (count < 0) return false;
     }
     return true;
   }
@@ -343,9 +342,9 @@ class MapEquality<K, V> implements Equality<Map<K, V>> {
   int hash(Map<K, V>? map) {
     if (map == null) return null.hashCode;
     var hash = 0;
-    for (var key in map.keys) {
+    for (var MapEntry(:key, :value) in map.entries) {
       var keyHash = _keyEquality.hash(key);
-      var valueHash = _valueEquality.hash(map[key] as V);
+      var valueHash = _valueEquality.hash(value);
       hash = (hash + 3 * keyHash + 7 * valueHash) & _hashMask;
     }
     hash = (hash + (hash << 3)) & _hashMask;


### PR DESCRIPTION
Initially I tried using `entries` instead of a `values` iterator, but that was surprisingly slow. This appears to be a good middle ground (see history of this comment for old results).

Hashing is about the same, but much faster for maps which don't have O(1) lookup. Equality is much faster.

## Benchmarks before:

DeepCollectionQualityUnordered.equals(RunTime): 7427.29020979021 us.
DeepCollectionQualityUnordered.hash(RunTime): 217.8173707406213 us.
DeepCollectionQuality.equals(RunTime): 2653.23875 us.
DeepCollectionQuality.hash(RunTime): 178.1674653887114 us.

## Benchmarks after:

DeepCollectionQualityUnordered.equals(RunTime): 4435.374 us.
DeepCollectionQualityUnordered.hash(RunTime): 212.8631545473818 us.
DeepCollectionQuality.equals(RunTime): 1989.1746626686656 us.
DeepCollectionQuality.hash(RunTime): 178.3396697902722 us.