### PR TITLE
update the pubspec version of package:collection

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.19.1-wip
+## 1.20.0-wip
 
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
   `Map.entries`.

--- a/pkgs/collection/pubspec.yaml
+++ b/pkgs/collection/pubspec.yaml
@@ -1,5 +1,5 @@
 name: collection
-version: 1.19.1-wip
+version: 1.20.0-wip
 description: >-
   Collections and utilities functions and classes related to collections.
 repository: https://github.com/dart-lang/core/tree/main/pkgs/collection


### PR DESCRIPTION
- update the pubspec version of package:collection; I believe this needs to be a new minor version due to the introduction of the `IterableMapEntryExtension` API

Done as a follow-up to https://github.com/dart-lang/core/pull/715.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
