### PR TITLE
add `ascending` to IterableExtension.sortedBy

### DIFF
--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -6,7 +6,6 @@ import 'dart:math' show Random;
 
 import 'algorithms.dart';
 import 'functions.dart' as functions;
-import 'utils.dart';
 
 /// Extensions that apply to all iterables.
 ///
@@ -71,10 +70,15 @@ extension IterableExtension<T> on Iterable<T> {
   /// Creates a sorted list of the elements of the iterable.
   ///
   /// The elements are ordered by the natural ordering of the
-  /// property [keyOf] of the element.
-  List<T> sortedBy<K extends Comparable<K>>(K Function(T element) keyOf) {
+  /// [keyOf] property when [ascending] is `true` or reverse ordering
+  /// when [ascending] is `false`.
+  List<T> sortedBy<K extends Comparable<K>>(
+    K Function(T element) keyOf, {
+    bool ascending = true,
+  }) {
+    int compare(K a, K b) => ascending ? a.compareTo(b) : b.compareTo(a);
     var elements = [...this];
-    mergeSortBy<T, K>(elements, keyOf, compareComparable);
+    mergeSortBy<T, K>(elements, keyOf, compare);
     return elements;
   }
 

--- a/pkgs/collection/test/extensions_test.dart
+++ b/pkgs/collection/test/extensions_test.dart
@@ -64,6 +64,16 @@ void main() {
         test('multiple', () {
           expect(iterable(<int>[3, 20, 100]).sortedBy(toString), [100, 20, 3]);
         });
+        test('multiple ascending', () {
+          expect(
+              iterable(<int>[3, 20, 100]).sortedBy(toString, ascending: true),
+              [100, 20, 3]);
+        });
+        test('multiple descending', () {
+          expect(
+              iterable(<int>[3, 20, 100]).sortedBy(toString, ascending: false),
+              [3, 20, 100]);
+        });
       });
       group('.sortedByCompare', () {
         test('empty', () {


### PR DESCRIPTION
`sortedBy` is one of the best extensions of this package.

It allows us to easily sort, but we can't set if the order comparaison is ascending/descending, it always defaults to "natural ordering".

This PR simplifies this process so we can simply decide it based on the added `ascending` parameter in the `sortedBy` extension.

```dart
  List<T> sortedBy<K extends Comparable<K>>(
    K Function(T element) keyOf, {
    bool ascending = true,
  })
```

This is useful, because without it, we would have to do additional operations bringing either more boilerplate or additional computations. By adding this named boolean we can make it straightforward.

For many developers, especially those who might not be as familiar with comparators and more advanced functional programming concepts, having a straightforward boolean parameter makes the API more accessible and user-friendly.

The boolean `ascending` is a natural state. It’s a common need to toggle sort order, and doing so with a single extension method and a simple parameter makes the code more readable and maintainable. Adopting this familiar pattern in `sortedBy` makes it feel more intuitive and consistent, making the intent of the code clearer.

Flutter itself uses this pattern for sorting, as we can see in `flutter/lib/src/material/data_table.dart`:

```dart
/// Signature for [DataColumn.onSort] callback.
typedef DataColumnSortCallback = void Function(int columnIndex, bool ascending);
```

I find this extension incredibly useful and have always relied on a version of it. I dedicated time to updating it for the community because I believe it addresses a fundamental and widely shared need across projects.

Thank you for taking the time to review this PR—I hope it proves valuable!

Added tests ✅
Retrocompatible ✅
Not a breaking change ✅

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
