### PR TITLE
Adds `[Heap]PriorityQueue.of` constructor.

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -5,6 +5,9 @@
   `Map.entries`.
 - Explicitly mark `BoolList` as `abstract interface`
 - Address diagnostics from `strict_top_level_inference`.
+- Optimize equality and hash code for maps by using `update` and a `values`
+  iterator to avoid extra lookups.
+- Add `PriorityQueue.of` constructor and optimize adding many elements.
 
 ## 1.19.1
 

--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Optimize equality and hash code for maps by using `update` and a `values`
   iterator to avoid extra lookups.
 - Add `PriorityQueue.of` constructor and optimize adding many elements.
+- Address diagnostics from `strict_top_level_inference`.
 
 ## 1.19.1
 

--- a/pkgs/collection/lib/src/priority_queue.dart
+++ b/pkgs/collection/lib/src/priority_queue.dart
@@ -22,9 +22,9 @@ import 'utils.dart';
 /// always give equal objects the same priority,
 /// otherwise [contains] or [remove] might not work correctly.
 abstract class PriorityQueue<E> {
-  /// Creates an empty [PriorityQueue].
+  /// Creates an empty priority queue.
   ///
-  /// The created [PriorityQueue] is a plain [HeapPriorityQueue].
+  /// The created `PriorityQueue` is a plain [HeapPriorityQueue].
   ///
   /// The [comparison] is a [Comparator] used to compare the priority of
   /// elements. An element that compares as less than another element has
@@ -36,15 +36,16 @@ abstract class PriorityQueue<E> {
   factory PriorityQueue([int Function(E, E)? comparison]) =
       HeapPriorityQueue<E>;
 
-  /// Create a new priority queue.
+  /// Creates a new [HeapPriorityQueue] containing [elements].
   ///
   /// The [comparison] is a [Comparator] used to compare the priority of
   /// elements. An element that compares as less than another element has
   /// a higher priority.
   ///
-  /// If [comparison] is omitted, it defaults to [Comparable.compare]. If this
-  /// is the case, `E` must implement [Comparable], and this is checked at
-  /// runtime for every comparison.
+  /// Unlike [PriorityQueue.new], the [comparison] cannot be omitted.
+  /// If the elements are comparable to each other, use [Comparable.compare]
+  /// as the comparison function, or use a more specialized function
+  /// if one is available.
   factory PriorityQueue.of(
           Iterable<E> elements, int Function(E, E) comparison) =
       HeapPriorityQueue<E>.of;
@@ -164,23 +165,30 @@ abstract class PriorityQueue<E> {
 ///
 /// The elements are kept in a heap structure,
 /// where the element with the highest priority is immediately accessible,
-/// and modifying a single element takes
-/// logarithmic time in the number of elements on average.
+/// and modifying a single element takes, on average,
+/// logarithmic time in the number of elements.
 ///
 /// * The [add] and [removeFirst] operations take amortized logarithmic time,
-///   O(log(n)), but may occasionally take linear time when growing the capacity
-///   of the heap.
-/// * The [addAll] operation works as doing repeated [add] operations.
+///   O(log(*N*)) where *N* is the number of elements, but may occasionally
+///   take linear time when growing the capacity of the heap.
+/// * The [addAll] operation works by doing repeated [add] operations.
+///   May be more efficient in some cases.
 /// * The [first] getter takes constant time, O(1).
 /// * The [clear] and [removeAll] methods also take constant time, O(1).
 /// * The [contains] and [remove] operations may need to search the entire
-///   queue for the elements, taking O(n) time.
-/// * The [toList] operation effectively sorts the elements, taking O(n*log(n))
+///   queue for the elements, taking O(*N*) time.
+/// * The [toList] operation effectively sorts the elements, taking O(n * log(*N*))
 ///   time.
 /// * The [toUnorderedList] operation copies, but does not sort, the elements,
 ///   and is linear, O(n).
-/// * The [toSet] operation effectively adds each element to the new set, taking
-///   an expected O(n*log(n)) time.
+/// * The [toSet] operation effectively adds each element to the new 
+///   [SplayTreeSet], taking an expected O(n * log(*N*)) time.
+///
+/// The [comparison] function is used to order elements, with earlier elements
+/// having higher priority. That is, elements are extracted from the queue
+/// in ascending [comparison] order.
+/// If two elements have the same priority, their ordering is unspecified
+/// and may be arbitary.
 class HeapPriorityQueue<E> implements PriorityQueue<E> {
   /// The comparison being used to compare the priority of elements.
   final int Function(E, E) comparison;
@@ -316,16 +324,14 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
 
   /// Removes all the elements from this queue and returns them.
   ///
-  /// The returned iterable has no specified order.
-  /// The operation does not copy the elements,
-  /// but instead keeps them in the existing heap structure,
-  /// and iterates over that directly.
+  /// The [HeapPriorityQueue] returns a [List] of its elements,
+  /// with no guaranteed order.
   @override
-  Iterable<E> removeAll() {
+  List<E> removeAll() {
     _modificationCount++;
     var result = _queue;
     _queue = <E>[];
-    return result.skip(0); // Hide list nature.
+    return result;
   }
 
   @override
@@ -401,7 +407,7 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
       } while (
           position > _queue.length); // Happens if last element is a left child.
     } while (position != 1); // At root again. Happens for right-most element.
-    return -1;
+    return -1;  
   }
 
   /// Place [element] in heap at [index] or above.

--- a/pkgs/collection/lib/src/priority_queue.dart
+++ b/pkgs/collection/lib/src/priority_queue.dart
@@ -177,8 +177,8 @@ abstract class PriorityQueue<E> {
 /// * The [clear] and [removeAll] methods also take constant time, O(1).
 /// * The [contains] and [remove] operations may need to search the entire
 ///   queue for the elements, taking O(*N*) time.
-/// * The [toList] operation effectively sorts the elements, taking O(n * log(*N*))
-///   time.
+/// * The [toList] operation effectively sorts the elements,
+///   taking O(n * log(*N*)) time.
 /// * The [toUnorderedList] operation copies, but does not sort, the elements,
 ///   and is linear, O(n).
 /// * The [toSet] operation effectively adds each element to the new
@@ -188,7 +188,7 @@ abstract class PriorityQueue<E> {
 /// having higher priority. That is, elements are extracted from the queue
 /// in ascending [comparison] order.
 /// If two elements have the same priority, their ordering is unspecified
-/// and may be arbitary.
+/// and may be arbitrary.
 class HeapPriorityQueue<E> implements PriorityQueue<E> {
   /// The comparison being used to compare the priority of elements.
   final int Function(E, E) comparison;

--- a/pkgs/collection/lib/src/priority_queue.dart
+++ b/pkgs/collection/lib/src/priority_queue.dart
@@ -183,7 +183,7 @@ abstract class PriorityQueue<E> {
 ///   an expected O(n*log(n)) time.
 class HeapPriorityQueue<E> implements PriorityQueue<E> {
   /// The comparison being used to compare the priority of elements.
-  final Comparator<E> comparison;
+  final int Function(E, E) comparison;
 
   /// List implementation of a heap.
   List<E> _queue;
@@ -212,7 +212,7 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
   /// The [comparison] is a [Comparator] used to compare the priority of
   /// elements. An element that compares as less than another element has
   /// a higher priority.
-  HeapPriorityQueue.of(Iterable<E> elements, int Function(E, E) this.comparison)
+  HeapPriorityQueue.of(Iterable<E> elements, this.comparison)
       : _queue = elements.toList() {
     _heapify();
   }
@@ -334,7 +334,7 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
     _modificationCount++;
     var result = _queue.first;
     var last = _queue.removeLast();
-    if (_queue.length > 0) {
+    if (_queue.isNotEmpty) {
       _bubbleDown(last, 0);
     }
     return result;
@@ -403,8 +403,6 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
     } while (position != 1); // At root again. Happens for right-most element.
     return -1;
   }
-
-  E _removeLast() => _queue.removeLast();
 
   /// Place [element] in heap at [index] or above.
   ///

--- a/pkgs/collection/lib/src/priority_queue.dart
+++ b/pkgs/collection/lib/src/priority_queue.dart
@@ -181,7 +181,7 @@ abstract class PriorityQueue<E> {
 ///   time.
 /// * The [toUnorderedList] operation copies, but does not sort, the elements,
 ///   and is linear, O(n).
-/// * The [toSet] operation effectively adds each element to the new 
+/// * The [toSet] operation effectively adds each element to the new
 ///   [SplayTreeSet], taking an expected O(n * log(*N*)) time.
 ///
 /// The [comparison] function is used to order elements, with earlier elements
@@ -326,6 +326,8 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
   ///
   /// The [HeapPriorityQueue] returns a [List] of its elements,
   /// with no guaranteed order.
+  ///
+  /// If the elements are not needed, use [clear] instead.
   @override
   List<E> removeAll() {
     _modificationCount++;
@@ -407,7 +409,7 @@ class HeapPriorityQueue<E> implements PriorityQueue<E> {
       } while (
           position > _queue.length); // Happens if last element is a left child.
     } while (position != 1); // At root again. Happens for right-most element.
-    return -1;  
+    return -1;
   }
 
   /// Place [element] in heap at [index] or above.

--- a/pkgs/collection/test/priority_queue_test.dart
+++ b/pkgs/collection/test/priority_queue_test.dart
@@ -23,6 +23,35 @@ void testDefault() {
   });
   testInt(PriorityQueue<int>.new);
   testCustom(PriorityQueue<C>.new);
+
+  group('(Heap)PriorityQueue.of returns functional priority queue', () {
+    List<int> extract(PriorityQueue<int> queue) {
+      var result = <int>[];
+      while (queue.isNotEmpty) {
+        result.add(queue.removeFirst());
+      }
+      return result;
+    }
+
+    for (var i = 0; i < 1024; i = i * 2 + 1) {
+      test('size $i', () {
+        var input = List<int>.generate(i, (x) => x);
+        for (var j = 0; j < 5; j++) {
+          var copy = (input.toList()..shuffle()).where((_) => true);
+          {
+            var queue = HeapPriorityQueue<int>.of(copy, (a, b) => a - b);
+            var elements = extract(queue);
+            expect(elements, input);
+          }
+          {
+            var queue = HeapPriorityQueue<int>.of(copy, (a, b) => a - b);
+            var elements = extract(queue);
+            expect(elements, input);
+          }
+        }
+      });
+    }
+  });
 }
 
 void testInt(PriorityQueue<int> Function() create) {

--- a/pkgs/collection/test/priority_queue_test.dart
+++ b/pkgs/collection/test/priority_queue_test.dart
@@ -307,9 +307,9 @@ void testConcurrentModification() {
       var q = HeapPriorityQueue<int>((a, b) => a - b)
         ..addAll([6, 4, 2, 3, 5, 8]);
       var e = q.unorderedElements;
-      q.add(12); // Modifiation before creating iterator is not a problem.
+      q.add(12); // Modification before creating iterator is not a problem.
       var it = e.iterator;
-      q.add(7); // Modification after creatig iterator is a problem.
+      q.add(7); // Modification after creating iterator is a problem.
       expect(it.moveNext, throwsConcurrentModificationError);
 
       it = e.iterator; // New iterator is not affected.
@@ -323,9 +323,9 @@ void testConcurrentModification() {
       var q = HeapPriorityQueue<int>((a, b) => a - b)
         ..addAll([6, 4, 2, 3, 5, 8]);
       var e = q.unorderedElements;
-      q.addAll([12]); // Modifiation before creating iterator is not a problem.
+      q.addAll([12]); // Modification before creating iterator is not a problem.
       var it = e.iterator;
-      q.addAll([7]); // Modification after creatig iterator is a problem.
+      q.addAll([7]); // Modification after creating iterator is a problem.
       expect(it.moveNext, throwsConcurrentModificationError);
       it = e.iterator; // New iterator is not affected.
       expect(it.moveNext(), true);
@@ -340,10 +340,10 @@ void testConcurrentModification() {
         ..addAll([6, 4, 2, 3, 5, 8]);
       var e = q.unorderedElements;
       expect(q.removeFirst(),
-          2); // Modifiation before creating iterator is not a problem.
+          2); // Modification before creating iterator is not a problem.
       var it = e.iterator;
       expect(q.removeFirst(),
-          3); // Modification after creatig iterator is a problem.
+          3); // Modification after creating iterator is a problem.
       expect(it.moveNext, throwsConcurrentModificationError);
 
       it = e.iterator; // New iterator is not affected.


### PR DESCRIPTION
Introduces efficient (linear-number of comparisons) "heapify" algorithm for converting an unsorted list to a heap-sorted list, using it for the `of` constructor, and after a large `addAll` operation, when it's presumed faster than just bubbling down all the new elements.

Also rewrites `HeapPriorityQueue` to use a growable list as backing array, instead of implementing the same thing using the double-when-full algorithm, and still having to deal with nullable cells. The platform growable list implementation is assumed to efficiently avoid some of those `null` checks.

Closes #732
