### PR TITLE
[fix,async] exception in async _CancelOnErrorSubscriptionWrapper.onError

### DIFF
--- a/pkgs/async/CHANGELOG.md
+++ b/pkgs/async/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.13.0
+
+- Fix type check and cast in SubscriptionStream's cancelOnError wrapper
+
 ## 2.12.0
 
 - Require Dart 3.4.

--- a/pkgs/async/lib/src/result/error.dart
+++ b/pkgs/async/lib/src/result/error.dart
@@ -53,7 +53,7 @@ class ErrorResult implements Result<Never> {
       errorHandler(error);
     } else {
       throw ArgumentError(
-        'is nor Function(Object, StackTrace) neither Function(Object)',
+        'is neither Function(Object, StackTrace) nor Function(Object)',
         'errorHandler',
       );
     }

--- a/pkgs/async/lib/src/result/error.dart
+++ b/pkgs/async/lib/src/result/error.dart
@@ -47,10 +47,15 @@ class ErrorResult implements Result<Never> {
   /// has to be a function expecting only one argument, which will be called
   /// with only the error.
   void handle(Function errorHandler) {
-    if (errorHandler is ZoneBinaryCallback) {
+    if (errorHandler is dynamic Function(Object, StackTrace)) {
       errorHandler(error, stackTrace);
+    } else if (errorHandler is dynamic Function(Object)) {
+      errorHandler(error);
     } else {
-      (errorHandler as ZoneUnaryCallback)(error);
+      throw ArgumentError(
+        'is nor Function(Object, StackTrace) neither Function(Object)',
+        'errorHandler',
+      );
     }
   }
 

--- a/pkgs/async/lib/src/subscription_stream.dart
+++ b/pkgs/async/lib/src/subscription_stream.dart
@@ -76,12 +76,20 @@ class _CancelOnErrorSubscriptionWrapper<T>
     super.onError((Object error, StackTrace stackTrace) {
       // Wait for the cancel to complete before sending the error event.
       super.cancel().whenComplete(() {
-        if (handleError is ZoneBinaryCallback<void, Object, StackTrace> || handleError is ZoneBinaryCallback) {
-          handleError?.call(error, stackTrace);
-        } else if (handleError is ZoneUnaryCallback<void, Object> || handleError is ZoneUnaryCallback) {
-          handleError?.call(error);
+        if (handleError is ZoneBinaryCallback<void, Object, StackTrace>) {
+          handleError(error, stackTrace);
+        } else if (handleError is ZoneBinaryCallback) {
+          handleError(error, stackTrace);
+        } else if (handleError is ZoneUnaryCallback<void, Object>) {
+          handleError(error);
+        } else if (handleError is ZoneUnaryCallback) {
+          handleError(error);
         }
       });
     });
   }
+}
+
+abstract class BinaryWrapper {
+  void binaryCall<T1, T2>(T1 t1, T2 t2);
 }

--- a/pkgs/async/lib/src/subscription_stream.dart
+++ b/pkgs/async/lib/src/subscription_stream.dart
@@ -76,13 +76,9 @@ class _CancelOnErrorSubscriptionWrapper<T>
     super.onError((Object error, StackTrace stackTrace) {
       // Wait for the cancel to complete before sending the error event.
       super.cancel().whenComplete(() {
-        if (handleError is ZoneBinaryCallback<void, Object, StackTrace>) {
+        if (handleError is dynamic Function(Object, StackTrace)) {
           handleError(error, stackTrace);
-        } else if (handleError is ZoneBinaryCallback) {
-          handleError(error, stackTrace);
-        } else if (handleError is ZoneUnaryCallback<void, Object>) {
-          handleError(error);
-        } else if (handleError is ZoneUnaryCallback) {
+        } else if (handleError is dynamic Function(Object)) {
           handleError(error);
         }
       });

--- a/pkgs/async/lib/src/subscription_stream.dart
+++ b/pkgs/async/lib/src/subscription_stream.dart
@@ -85,7 +85,3 @@ class _CancelOnErrorSubscriptionWrapper<T>
     });
   }
 }
-
-abstract class BinaryWrapper {
-  void binaryCall<T1, T2>(T1 t1, T2 t2);
-}

--- a/pkgs/async/lib/src/subscription_stream.dart
+++ b/pkgs/async/lib/src/subscription_stream.dart
@@ -76,10 +76,10 @@ class _CancelOnErrorSubscriptionWrapper<T>
     super.onError((Object error, StackTrace stackTrace) {
       // Wait for the cancel to complete before sending the error event.
       super.cancel().whenComplete(() {
-        if (handleError is ZoneBinaryCallback) {
-          handleError(error, stackTrace);
-        } else if (handleError != null) {
-          (handleError as ZoneUnaryCallback)(error);
+        if (handleError is ZoneBinaryCallback<void, Object, StackTrace> || handleError is ZoneBinaryCallback) {
+          handleError?.call(error, stackTrace);
+        } else if (handleError is ZoneUnaryCallback<void, Object> || handleError is ZoneUnaryCallback) {
+          handleError?.call(error);
         }
       });
     });

--- a/pkgs/async/pubspec.yaml
+++ b/pkgs/async/pubspec.yaml
@@ -1,5 +1,5 @@
 name: async
-version: 2.12.0
+version: 2.13.0
 description: Utility functions and classes related to the 'dart:async' library.
 repository: https://github.com/dart-lang/core/tree/main/pkgs/async
 issue_tracker: https://github.com/dart-lang/core/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aasync

--- a/pkgs/async/test/result/result_test.dart
+++ b/pkgs/async/test/result/result_test.dart
@@ -281,6 +281,29 @@ void main() {
     expect(called, isTrue);
   });
 
+  test('handle typed binary', () {
+    final result = ErrorResult('error', stack);
+    var called = false;
+    void f(Object error, StackTrace stackTrace) {
+      called = true;
+    }
+
+    result.handle(f);
+    expect(called, isTrue);
+  });
+
+  test('handle typed unary', () {
+    final result = ErrorResult('error', stack);
+    var called = false;
+
+    void f(Object error) {
+      called = true;
+    }
+
+    result.handle(f);
+    expect(called, isTrue);
+  });
+
   test('handle unary and binary', () {
     var result = ErrorResult('error', stack);
     var called = false;

--- a/pkgs/async/test/subscription_stream_test.dart
+++ b/pkgs/async/test/subscription_stream_test.dart
@@ -148,7 +148,79 @@ void main() {
       });
     }
   });
+
+  group('subscriptionStream error callback', () {
+    test('- binary typed', () async {
+      var completer = Completer<void>();
+      var stream = createErrorStream();
+      var sourceSubscription = stream.listen(null, cancelOnError: true);
+      var subscriptionStream = SubscriptionStream(sourceSubscription);
+
+      void f(Object error, StackTrace stackTrace) {
+        completer.complete();
+      }
+
+      subscriptionStream.listen((_) {},
+          onError: f,
+          onDone: () => throw 'should not happen',
+          cancelOnError: true);
+      await completer.future;
+      await flushMicrotasks();
+    });
+
+    test('- binary dynamic', () async {
+      var completer = Completer<void>();
+      var stream = createErrorStream();
+      var sourceSubscription = stream.listen(null, cancelOnError: true);
+      var subscriptionStream = SubscriptionStream(sourceSubscription);
+
+      subscriptionStream.listen((_) {},
+          onError: (error, stackTrace) {
+            completer.complete();
+          },
+          onDone: () => throw 'should not happen',
+          cancelOnError: true);
+      await completer.future;
+      await flushMicrotasks();
+    });
+
+    test('- unary typed', () async {
+      var completer = Completer<void>();
+      var stream = createErrorStream();
+      var sourceSubscription = stream.listen(null, cancelOnError: true);
+      var subscriptionStream = SubscriptionStream(sourceSubscription);
+
+      void f(Object error) {
+        completer.complete();
+      }
+
+      subscriptionStream.listen((_) {},
+          onError: f,
+          onDone: () => throw 'should not happen',
+          cancelOnError: true);
+      await completer.future;
+      await flushMicrotasks();
+    });
+
+    test('- unary dynamic', () async {
+      var completer = Completer<void>();
+      var stream = createErrorStream();
+      var sourceSubscription = stream.listen(null, cancelOnError: true);
+      var subscriptionStream = SubscriptionStream(sourceSubscription);
+
+      subscriptionStream.listen((_) {},
+          onError: (error) {
+            completer.complete();
+          },
+          onDone: () => throw 'should not happen',
+          cancelOnError: true);
+      await completer.future;
+      await flushMicrotasks();
+    });
+  });
 }
+
+typedef BinaryFunc = void Function(Object s, StackTrace tr);
 
 Stream<int> createStream() async* {
   yield 1;

--- a/pkgs/async/test/subscription_stream_test.dart
+++ b/pkgs/async/test/subscription_stream_test.dart
@@ -150,7 +150,7 @@ void main() {
   });
 
   group('subscriptionStream error callback', () {
-    test('- binary typed', () async {
+    test('binary typed', () async {
       var completer = Completer<void>();
       var stream = createErrorStream();
       var sourceSubscription = stream.listen(null, cancelOnError: true);
@@ -168,7 +168,7 @@ void main() {
       await flushMicrotasks();
     });
 
-    test('- binary dynamic', () async {
+    test('binary dynamic', () async {
       var completer = Completer<void>();
       var stream = createErrorStream();
       var sourceSubscription = stream.listen(null, cancelOnError: true);
@@ -184,7 +184,7 @@ void main() {
       await flushMicrotasks();
     });
 
-    test('- unary typed', () async {
+    test('unary typed', () async {
       var completer = Completer<void>();
       var stream = createErrorStream();
       var sourceSubscription = stream.listen(null, cancelOnError: true);
@@ -202,7 +202,7 @@ void main() {
       await flushMicrotasks();
     });
 
-    test('- unary dynamic', () async {
+    test('unary dynamic', () async {
       var completer = Completer<void>();
       var stream = createErrorStream();
       var sourceSubscription = stream.listen(null, cancelOnError: true);
@@ -219,8 +219,6 @@ void main() {
     });
   });
 }
-
-typedef BinaryFunc = void Function(Object s, StackTrace tr);
 
 Stream<int> createStream() async* {
   yield 1;


### PR DESCRIPTION
Patch fixes exception in async (template cast seems to be changed in dart):

```
Unhandled exception:
type '(Object, StackTrace) => void' is not a subtype of type '(dynamic) => dynamic' in type cast
#0      _CancelOnErrorSubscriptionWrapper.onError.<anonymous closure>.<anonymous closure> (package:async/src/subscription_stream.dart:82:24)
#1      _RootZone.run (dart:async/zone.dart:1670:54)
#2      _FutureListener.handleWhenComplete (dart:async/future_impl.dart:247:18)
#3      Future._propagateToListeners.handleWhenCompleteCallback (dart:async/future_impl.dart:872:39)
#4      Future._propagateToListeners (dart:async/future_impl.dart:928:11)
#5      Future._addListener.<anonymous closure> (dart:async/future_impl.dart:513:9)
#6      _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
#7      _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
#8      _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
#9      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:185:5)
```