### PR TITLE
feat: support web in package:platform

### DIFF
--- a/pkgs/platform/lib/platform.dart
+++ b/pkgs/platform/lib/platform.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 // Core interfaces & classes.
-export 'src/interface/local_platform.dart';
+export 'src/interface/local_platform.dart'
+    if (dart.library.js_interop) 'src/interface/local_platform_web.dart';
 export 'src/interface/platform.dart';
 export 'src/testing/fake_platform.dart';

--- a/pkgs/platform/lib/src/interface/local_platform_web.dart
+++ b/pkgs/platform/lib/src/interface/local_platform_web.dart
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'platform.dart';
+
+/// `Platform` implementation that .
+class LocalPlatform extends Platform {
+  /// Creates a new [LocalPlatform].
+  const LocalPlatform();
+
+  @override
+  int get numberOfProcessors => 0;
+
+  @override
+  String get pathSeparator => '/';
+
+  @override
+  String get operatingSystem => 'TODO'; // see web.window.navigator.platform
+
+  @override
+  String get operatingSystemVersion => 'TODO';
+
+  @override
+  String get localHostname => 'TODO';
+
+  @override
+  Map<String, String> get environment => {};
+
+  @override
+  String get executable => 'TODO';
+
+  @override
+  String get resolvedExecutable => 'TODO';
+
+  @override
+  Uri get script => Uri.base;
+
+  @override
+  List<String> get executableArguments => [];
+
+  @override
+  String? get packageConfig => 'TODO';
+
+  @override
+  String get version => 'TODO';
+
+  @override
+  bool get stdinSupportsAnsi => false;
+
+  @override
+  bool get stdoutSupportsAnsi => false;
+
+  @override
+  String get localeName => 'TODO';
+}


### PR DESCRIPTION
[`platform`](https://pub.dev/packages/platform) provides a mockable interface for dart:io platform. [I've suggested](https://github.com/getsentry/sentry-dart/issues/2646) to the team that we use it to replace our custom implemention of the same concept with this package. 

However, I've failed to notice that pub.dev/packages/platform does not support web.

My suggestion is to add this, even if it's just with the information that can be gather with what is available on web. 
Note: I have not actually researched and implemented any of the specific getters, just wanted to verify that it would make sense and wanted to show how it could look like in the code, with the conditional export.

If maintainers are open to introducing dart2js & dart2wasm support, I could update the code in `local_platform_web.dart` and add tests


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
