### PR TITLE
add strict_top_level_inference to the core lint set

### DIFF
--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 6.0.0-wip
 
+- `core`:
+  - added [strict_top_level_inference] (https://github.com/dart-lang/core/issues/836)
 - `recommended`:
   - added [unnecessary_underscores] (https://github.com/dart-lang/core/issues/856)
 - Require Dart 3.7.

--- a/pkgs/lints/lib/core.yaml
+++ b/pkgs/lints/lib/core.yaml
@@ -33,6 +33,7 @@ linter:
     - prefer_typing_uninitialized_variables
     - provide_deprecation_message
     - secure_pubspec_urls
+    - strict_top_level_inference
     - type_literal_in_constant_pattern
     - unintended_html_in_doc_comment
     - unnecessary_overrides

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -32,6 +32,7 @@
 | [`prefer_typing_uninitialized_variables`](https://dart.dev/lints/prefer_typing_uninitialized_variables) | Prefer typing uninitialized variables and fields. | ✅ |
 | [`provide_deprecation_message`](https://dart.dev/lints/provide_deprecation_message) | Provide a deprecation message, via `@Deprecated("message")`. |  |
 | [`secure_pubspec_urls`](https://dart.dev/lints/secure_pubspec_urls) | Use secure urls in `pubspec.yaml`. |  |
+| [`strict_top_level_inference`](https://dart.dev/lints/strict_top_level_inference) | Specify type annotations. | ✅ |
 | [`type_literal_in_constant_pattern`](https://dart.dev/lints/type_literal_in_constant_pattern) | Don't use constant patterns with type literals. | ✅ |
 | [`unintended_html_in_doc_comment`](https://dart.dev/lints/unintended_html_in_doc_comment) | Use of angle brackets in a doc comment is treated as HTML by Markdown. |  |
 | [`unnecessary_overrides`](https://dart.dev/lints/unnecessary_overrides) | Don't override a method to do a super method invocation with the same parameters. | ✅ |


### PR DESCRIPTION
- add `strict_top_level_inference` to the core lint set
- closes https://github.com/dart-lang/core/issues/836

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
