### PR TITLE
Contribute a Gemini Code Assist config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,19 @@
+# A configuration files for the Gemini Code Assist bot.
+#
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github.
+
+# No poems please.
+have_fun: false
+
+code_review:
+  # Options here are LOW, MEDIUM, HIGH, and CRITICAL. The default is MEDIUM.
+  comment_severity_threshold: MEDIUM
+
+  # Configure the behavior for PR opened events.
+  pull_request_opened:
+    # Keep the default of no help message comments when pull requests are opened.
+    help: false
+    # This is noisy; disable.
+    summary: false
+    # Keep this on for now.
+    code_review: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,17 @@
+# The dart-lang Dart style guide
+
+## Introduction
+
+This style guide outlines the coding conventions for Dart code contributed to
+dart-lang repositories. All Dart code should follow the Effective Dart style
+guide (https://dart.dev/effective-dart/style).
+
+## Contribution Guidelines
+
+- larger or significant changes should be discussed in an issue before creating
+  a PR
+- contributions to our repos should follow the Dart style guide and use 'dart
+  format'
+- most changes should add an entry to the changelog and may need to rev the
+  pubspec package version
+- changes to packages require corresponding tests


### PR DESCRIPTION
Contribute a Gemini Code Assist config:

- contribute a Gemini Code Assist config (docs at https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github)
- disable the initial PR summary
- keep the code review comment on PR open
- keep the 'comment severity' at medium; we should consider increasing to high based on the reviews we see
- contribute a brief style guide; mention Effective Dart and the 3-4 things we already say on each PR

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
