### PR TITLE
Adjust the implements clause of IntX

### DIFF
--- a/pkgs/fixnum/CHANGELOG.md
+++ b/pkgs/fixnum/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+* Change `IntX` such that it implements `Comparable<IntX>`. This makes it
+  possible for `IntX` (and in turn `Int64` and `Int32`) be used with methods
+  like `sortedBy` in the platform libraries.
+
 ## 1.1.1
 
 * Require Dart `^3.1.0`

--- a/pkgs/fixnum/CHANGELOG.md
+++ b/pkgs/fixnum/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0
+## 1.2.0-wip
 
 * Change `IntX` such that it implements `Comparable<IntX>`. This makes it
   possible for `IntX` (and in turn `Int64` and `Int32`) be used with methods

--- a/pkgs/fixnum/lib/src/intx.dart
+++ b/pkgs/fixnum/lib/src/intx.dart
@@ -6,7 +6,7 @@ import 'int32.dart';
 import 'int64.dart';
 
 /// A fixed-precision integer.
-abstract class IntX implements Comparable<Object> {
+abstract class IntX implements Comparable<IntX> {
   /// Addition operator.
   IntX operator +(Object other);
 

--- a/pkgs/fixnum/pubspec.yaml
+++ b/pkgs/fixnum/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 1.1.1
+version: 1.2.0
 description: >-
   Library for 32- and 64-bit signed fixed-width integers with consistent
   behavior between native and JS runtimes.

--- a/pkgs/fixnum/pubspec.yaml
+++ b/pkgs/fixnum/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fixnum
-version: 1.2.0
+version: 1.2.0-wip
 description: >-
   Library for 32- and 64-bit signed fixed-width integers with consistent
   behavior between native and JS runtimes.


### PR DESCRIPTION
Adjust the implements clause of IntX.

See https://github.com/dart-lang/sdk/issues/59776 for breaking change processing.

Currently, `IntX` implements `Comparable<Object>`. This causes the equation `X extends Comparable<X>` to have no solution which is a supertype of `IntX` (and, hence, `Int64` and `Int32`). This is inconvenient because it causes invocations of methods like the extension method `sortedBy` to fail: There is no actual type argument that satisfies the constraints.

With this PR, `IntX` is a subtype of `Comparable<IntX>`, which means that said methods can now be invoked. Type inference fails when the language version is below 3.7.0 (so the type argument `IntX` must be provided explicitly), but from 3.7.0 and up the feature 'inference-using-bounds' is enabled by default, and type inference will then succeed.