### PR TITLE
[collection] explicitly make BoolList abstract interface

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
   `Map.entries`.
+- Explicitly mark `BoolList` as `abstract interface`
 - Address diagnostics from `strict_top_level_inference`.
 
 ## 1.19.1

--- a/pkgs/collection/lib/src/boollist.dart
+++ b/pkgs/collection/lib/src/boollist.dart
@@ -10,7 +10,7 @@ import 'unmodifiable_wrappers.dart' show NonGrowableListMixin;
 /// A space-efficient list of boolean values.
 ///
 /// Uses list of integers as internal storage to reduce memory usage.
-abstract /*mixin*/ class BoolList with ListMixin<bool> {
+abstract interface class BoolList with ListMixin<bool> {
   static const int _entryShift = 5;
 
   static const int _bitsPerEntry = 32;
@@ -180,7 +180,7 @@ abstract /*mixin*/ class BoolList with ListMixin<bool> {
   }
 }
 
-class _GrowableBoolList extends BoolList {
+final class _GrowableBoolList extends BoolList {
   static const int _growthFactor = 2;
 
   _GrowableBoolList._withCapacity(int length, int capacity)
@@ -228,7 +228,8 @@ class _GrowableBoolList extends BoolList {
   }
 }
 
-class _NonGrowableBoolList extends BoolList with NonGrowableListMixin<bool> {
+final class _NonGrowableBoolList extends BoolList
+    with NonGrowableListMixin<bool> {
   _NonGrowableBoolList._withCapacity(int length, int capacity)
       : super._(
           Uint32List(BoolList._lengthInWords(capacity)),

--- a/pkgs/collection/lib/src/boollist.dart
+++ b/pkgs/collection/lib/src/boollist.dart
@@ -169,7 +169,7 @@ abstract interface class BoolList with ListMixin<bool> {
   @override
   Iterator<bool> get iterator => _BoolListIterator(this);
 
-  /// Note: [index] is NOT checked for validity.
+  // Note: [index] is NOT checked for validity.
   void _setBit(int index, bool value) {
     if (value) {
       _data[index >> _entryShift] |= 1 << (index & _entrySignBitIndex);
@@ -178,7 +178,7 @@ abstract interface class BoolList with ListMixin<bool> {
     }
   }
 
-  /// Note: [index] is NOT checked for validity.
+  // Note: [index] is NOT checked for validity.
   bool _getBit(int index) =>
       (_data[index >> _entryShift] & (1 << (index & _entrySignBitIndex))) != 0;
 

--- a/pkgs/collection/lib/src/boollist.dart
+++ b/pkgs/collection/lib/src/boollist.dart
@@ -179,6 +179,9 @@ abstract interface class BoolList with ListMixin<bool> {
   }
 
   // Note: [index] is NOT checked for validity.
+  @pragma('dart2js:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('wasm:prefer-inline')
   bool _getBit(int index) =>
       (_data[index >> _entryShift] & (1 << (index & _entrySignBitIndex))) != 0;
 

--- a/pkgs/collection/pubspec.yaml
+++ b/pkgs/collection/pubspec.yaml
@@ -12,6 +12,9 @@ topics:
 environment:
   sdk: ^3.4.0
 
+dependencies:
+  meta: ^1.16.0
+
 dev_dependencies:
   benchmark_harness: ^2.3.1
   dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
It couldn't be extended in practice since it doesn't have a
public constructor

Also made the only implementations final
