### PR TITLE
prep to publish 6.0.0 of package:lints

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -10,5 +10,6 @@ jobs:
     with:
       ignore_coverage: "**.mock.dart,**.g.dart"
       ignore_license: "**.mock.dart,**.g.dart,**.mocks.dart,pkgs/platform/*"
+      sdk: beta
     permissions:
       pull-requests: write

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -26,7 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [dev, beta, stable]
+        # TODO: Re-add stable to the matrix once 3.8 is out.
+        sdk: [dev, beta]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
+      sdk: beta
       write-comments: false
     permissions:
       id-token: write

--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.0-wip
+## 6.0.0
 
 - `core`:
   - added [strict_top_level_inference] (https://github.com/dart-lang/core/issues/836)

--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -4,7 +4,7 @@
   - added [strict_top_level_inference] (https://github.com/dart-lang/core/issues/836)
 - `recommended`:
   - added [unnecessary_underscores] (https://github.com/dart-lang/core/issues/856)
-- Require Dart 3.7.
+- Require Dart 3.8.
 
 [strict_top_level_inference]: https://dart.dev/lints/strict_top_level_inference
 [unnecessary_underscores]: https://dart.dev/lints/unnecessary_underscores

--- a/pkgs/lints/README.md
+++ b/pkgs/lints/README.md
@@ -28,8 +28,8 @@ Additionally, a third lint set -
 recommended set with additional recommended Flutter-specific lints.
 
 The Dart team will likely not provide recommendations past the `core` and
-`recommended` sets (e.g., a `strict` rule set). However, there are many such rule
-sets in the ecosystem (available at [pub.dev](https://pub.dev/)).
+`recommended` sets (e.g., a `strict` rule set). However, there are many such
+rule sets in the ecosystem (available at [pub.dev](https://pub.dev/)).
 
 Rule set authors: consider adding the `lints` topic to your pubspec to allow
 easier discovery (e.g.,

--- a/pkgs/lints/pubspec.yaml
+++ b/pkgs/lints/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 6.0.0-wip
+version: 6.0.0
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.

--- a/pkgs/lints/pubspec.yaml
+++ b/pkgs/lints/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0-0
 
 # NOTE: Code is not allowed in this package - do not add dependencies.
 # dependencies:


### PR DESCRIPTION
- prep to publish 6.0.0 of package:lints

It's been several major SDK releases since we last published so I think we can publish the queued changes. Some notes:

- we added `strict_top_level_inference` to core
- we added `unnecessary_underscores` to recommended
- this won't be in time to land updated new `dart create` and `flutter create` templates - referencing this new version - for Dart 3.8. That's probably ok.
- there was a fix for `strict_top_level_inference` which was not in the 3.7 sdk release but will be in the 3.8 one; https://github.com/dart-lang/sdk/issues/60136 - 'strict_top_level_inference is triggered for wildcard variables'

Given that last fix (which improves the correctness for wildcard variables, but wouldn't have been a showstopper for shipping the lint) we could either keep the required min sdk at 3.7 (the current value), or bump it to 3.8.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
