### PR TITLE
Speedup package:crypto (with a focus on md5)

### DIFF
--- a/pkgs/crypto/lib/src/hash_sink.dart
+++ b/pkgs/crypto/lib/src/hash_sink.dart
@@ -88,24 +88,26 @@ abstract class HashSink implements Sink<List<int>> {
     final size = _currentChunk.length;
     _byteDataView ??= _currentChunk.buffer.asByteData();
     while (true) {
-      // Is there enough data left for (a) full chunk(s)?
+      // Is there enough data left in [data] for a full chunk?
       var restEnd = currentChunkNextIndex + data.length - dataIdx;
       if (restEnd < size) {
-        // No. Just add into saved data.
+        // No. Just add into [_currentChunk].
         _currentChunk.setRange(currentChunkNextIndex, restEnd, data, dataIdx);
         _currentChunkNextIndex = restEnd;
         return;
       }
 
-      // Yes. Fill out the chunk and process it.
+      // Yes. Fill out [_currentChunk] and process it.
       _currentChunk.setRange(currentChunkNextIndex, size, data, dataIdx);
       dataIdx += size - currentChunkNextIndex;
 
       // Now do endian conversion to words.
-      for (var j = 0; j < _currentChunk32.length; j++) {
+      var j = 0;
+      do {
         _currentChunk32[j] =
             _byteDataView!.getUint32(j * bytesPerWord, _endian);
-      }
+        j++;
+      } while (j < _currentChunk32.length);
 
       updateHash(_currentChunk32);
       currentChunkNextIndex = 0;

--- a/pkgs/crypto/lib/src/hash_sink.dart
+++ b/pkgs/crypto/lib/src/hash_sink.dart
@@ -19,8 +19,7 @@ abstract class HashSink implements Sink<List<int>> {
 
   /// The words in the current chunk.
   ///
-  /// This is an instance variable to avoid re-allocating, but its data isn't
-  /// used across invocations of [_iterate].
+  /// This is an instance variable to avoid re-allocating.
   ByteData? _byteDataView;
   final Uint8List _currentChunk;
   int _currentChunkNextIndex;
@@ -138,7 +137,7 @@ abstract class HashSink implements Sink<List<int>> {
     return byteDigest;
   }
 
-  /// Finalizes [_pendingData].
+  /// Finalizes the data and finishes the hash.
   ///
   /// This adds a 1 bit to the end of the message, and expands it with 0 bits to
   /// pad it out.

--- a/pkgs/crypto/lib/src/md5.dart
+++ b/pkgs/crypto/lib/src/md5.dart
@@ -85,24 +85,11 @@ class _MD5Sink extends HashSink {
     var c = digest[2];
     var d = digest[3];
 
-    int e;
-    int f;
+    var e = -1;
+    var f = -1;
 
-    for (var i = 0; i < 64; i++) {
-      if (i < 16) {
-        e = (b & c) | ((~b & mask32) & d);
-        f = i;
-      } else if (i < 32) {
-        e = (d & b) | ((~d & mask32) & c);
-        f = ((5 * i) + 1) % 16;
-      } else if (i < 48) {
-        e = b ^ c ^ d;
-        f = ((3 * i) + 5) % 16;
-      } else {
-        e = c ^ (b | (~d & mask32));
-        f = (7 * i) % 16;
-      }
-
+    @pragma('vm:prefer-inline')
+    void round(int i) {
       var temp = d;
       d = c;
       c = b;
@@ -114,6 +101,30 @@ class _MD5Sink extends HashSink {
         ),
       );
       a = temp;
+    }
+
+    for (var i = 0; i < 16; i++) {
+      e = (b & c) | ((~b & mask32) & d);
+      f = i;
+      round(i);
+    }
+
+    for (var i = 16; i < 32; i++) {
+      e = (d & b) | ((~d & mask32) & c);
+      f = ((5 * i) + 1) % 16;
+      round(i);
+    }
+
+    for (var i = 32; i < 48; i++) {
+      e = b ^ c ^ d;
+      f = ((3 * i) + 5) % 16;
+      round(i);
+    }
+
+    for (var i = 48; i < 64; i++) {
+      e = c ^ (b | (~d & mask32));
+      f = (7 * i) % 16;
+      round(i);
     }
 
     digest[0] = add32(a, digest[0]);

--- a/pkgs/crypto/utils/md5sum.dart
+++ b/pkgs/crypto/utils/md5sum.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+void main(List<String> args) {
+  for (var arg in args) {
+    var data = File(arg).readAsBytesSync();
+    var stopwatch = Stopwatch()..start();
+    var hash = md5.convert(data);
+    stopwatch.stop();
+    print('Hashed to ${hash.toString()} in '
+        '${stopwatch.elapsedMilliseconds} ms');
+  }
+}

--- a/pkgs/crypto/utils/md5sum.dart
+++ b/pkgs/crypto/utils/md5sum.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';


### PR DESCRIPTION
**TL;DR**
This makes it faster and use less ram.

**Details**
Tested on `out/ReleaseX64/wasm-opt` from a dart sdk build (167MB):

JIT, `dart --deterministic`:

```
Difference at 95.0% confidence
        -313.4 +/- 44.2824
        -22.8359% +/- 3.22664%
        (Student's t, pooled s = 30.3628)
```

JIT, `dart`:

```
Difference at 95.0% confidence
        -275.6 +/- 43.5498
        -20.1905% +/- 3.19046%
        (Student's t, pooled s = 29.8605)
```

AOT, `dartaotruntime --deterministic`:

```
Difference at 95.0% confidence
        -499 +/- 11.5944
        -40.3135% +/- 0.936693%
        (Student's t, pooled s = 7.94984)
```

AOT, `dartaotruntime`:

```
Difference at 95.0% confidence
        -506.8 +/- 39.0824
        -41.304% +/- 3.1852%
        (Student's t, pooled s = 26.7974)
```

Running the AOT snapshots through the "benchmarker" utility from dart front_end I get these results (with 25 runs of each version):

```
msec task-clock:u: -41.1276% +/- 0.3390% (-515.19 +/- 4.25) (1252.67 -> 737.48)
page-faults:u: -55.7760% +/- 0.1266% (-655.48 +/- 1.49) (1175.20 -> 519.72)
cycles:u: -41.7236% +/- 0.3140% (-2185317986.60 +/- 16443529.36) (5237610655.96 -> 3052292669.36)
instructions:u: -32.5192% +/- 0.0000% (-5346525546.76 +/- 2905.52) (16441121298.68 -> 11094595751.92)
branch-misses:u: -97.0502% +/- 0.3379% (-8025400.44 +/- 27942.52) (8269332.32 -> 243931.88)
seconds time elapsed: -41.0827% +/- 0.3407% (-0.52 +/- 0.00) (1.25 -> 0.74)
seconds user: -41.7571% +/- 0.4373% (-0.50 +/- 0.01) (1.19 -> 0.70)
seconds sys: -27.8724% +/- 4.1716% (-0.02 +/- 0.00) (0.06 -> 0.04)
MarkSweep(   old space) goes from 2 to 1
```

Running it through `/usr/bin/time -v` reports the "Maximum resident set size (kbytes)" going from around ~346k to ~176k (i.e. uses about half the ram).

MD5 calculations is used internally in the analyzer, and patching this in, for an AOT compile of the analyzer we see changes like this (when run through the benchmarker with parameters like `--train-using pkg/front_end/lib/` in the dart sdk):

```
msec task-clock:u: -1.2865% +/- 0.2432% (-105.99 +/- 20.03) (8238.61 -> 8132.62)
page-faults:u: -6.7334% +/- 0.0969% (-10705.66 +/- 154.06) (158992.30 -> 148286.64)
cycles:u: -1.1201% +/- 0.2487% (-384785056.06 +/- 85428229.56) (34351469228.82 -> 33966684172.76)
instructions:u: -2.6679% +/- 0.0191% (-1227909335.74 +/- 8796243.14) (46025301866.14 -> 44797392530.40)
branch-misses:u: -1.5364% +/- 0.9908% (-1886562.18 +/- 1216638.62) (122788764.20 -> 120902202.02)
seconds time elapsed: -1.3342% +/- 0.2478% (-0.11 +/- 0.02) (8.27 -> 8.16)
seconds user: -1.0854% +/- 0.2985% (-0.09 +/- 0.02) (7.88 -> 7.79)
seconds sys: -5.8743% +/- 3.7392% (-0.02 +/- 0.01) (0.36 -> 0.34)
Scavenge(   new space) goes from 134 to 131
MarkSweep(   old space) goes from 3 to 2
```