### PR TITLE
Fix short flag parsing to strip equals sign from value

### DIFF
--- a/pkgs/args/lib/src/parser.dart
+++ b/pkgs/args/lib/src/parser.dart
@@ -207,6 +207,11 @@ class Parser {
       // The first character is a non-flag option, so the rest must be the
       // value.
       var value = '${lettersAndDigits.substring(1)}$rest';
+      // If the value starts with '=' (like in -o=value), strip it to match
+      // the behavior of long options (--option=value).
+      if (value.startsWith('=')) {
+        value = value.substring(1);
+      }
       _setOption(_results, first, value, '-$c');
     } else {
       // If we got some non-flag characters, then it must be a value, but

--- a/pkgs/args/test/short_flag_equals_test.dart
+++ b/pkgs/args/test/short_flag_equals_test.dart
@@ -1,0 +1,64 @@
+import 'package:args/args.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Short flag with equals syntax', () {
+    test('should parse value correctly without including equals sign', () {
+      final parser = ArgParser();
+      parser.addOption('option', abbr: 'o');
+
+      // Test long flag with equals
+      final result1 = parser.parse(['--option=value']);
+      expect(result1['option'], equals('value'));
+
+      // Test short flag with equals - currently fails
+      final result2 = parser.parse(['-o=value']);
+      expect(result2['option'], equals('value')); // Currently gets '=value'
+
+      // Test short flag with space (this works correctly)
+      final result3 = parser.parse(['-o', 'value']);
+      expect(result3['option'], equals('value'));
+
+      // All three should produce the same result
+      expect(result1['option'], equals(result2['option']));
+      expect(result2['option'], equals(result3['option']));
+    });
+
+    test('should handle complex values with equals', () {
+      final parser = ArgParser();
+      parser.addOption('config', abbr: 'c');
+
+      final result1 = parser.parse(['--config=key=value']);
+      final result2 = parser.parse(['-c=key=value']);
+
+      expect(result1['config'], equals('key=value'));
+      expect(result2['config'],
+          equals('key=value')); // Currently gets '=key=value'
+    });
+
+    test('should handle empty value after equals', () {
+      final parser = ArgParser();
+      parser.addOption('value', abbr: 'v');
+
+      final result1 = parser.parse(['--value=']);
+      final result2 = parser.parse(['-v=']);
+
+      expect(result1['value'], equals(''));
+      expect(result2['value'], equals('')); // Currently gets '='
+    });
+
+    test('should work with real-world example (bundle ID)', () {
+      final parser = ArgParser();
+      parser.addOption('ios-bundle-id', abbr: 'i');
+
+      final bundleId = 'com.example.app';
+
+      final result1 = parser.parse(['--ios-bundle-id=$bundleId']);
+      final result2 = parser.parse(['-i=$bundleId']);
+
+      expect(result1['ios-bundle-id'], equals(bundleId));
+      expect(result2['ios-bundle-id'],
+          equals(bundleId)); // Currently gets '=com.example.app'
+    });
+  });
+}


### PR DESCRIPTION
When parsing short flags with equals syntax (e.g., -o=value), the parser was incorrectly including the equals sign in the parsed value, resulting in '=value' instead of 'value'. This was inconsistent with long flag parsing (--option=value) which correctly returned 'value'.

This fix strips the leading equals sign when present, making short and long flag parsing consistent.

This fixes issues in tools like FlutterFire CLI where users expect -i=bundleid to work the same as --ios-bundle-id=bundleid.

Fixes #908 
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
