### PR TITLE
fix(crypto): update conditional import for js interop library

### DIFF
--- a/pkgs/crypto/CHANGELOG.md
+++ b/pkgs/crypto/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Run `dart format` with the new style.
 - Performance improvements.
+- Updated web conditional import to use `js_interop` to support WebAssembly
 
 ## 3.0.6
 

--- a/pkgs/crypto/lib/src/sha512.dart
+++ b/pkgs/crypto/lib/src/sha512.dart
@@ -7,7 +7,8 @@ import 'dart:convert';
 import 'digest.dart';
 import 'hash.dart';
 // ignore: uri_does_not_exist
-import 'sha512_fastsinks.dart' if (dart.library.js) 'sha512_slowsinks.dart';
+import 'sha512_fastsinks.dart'
+    if (dart.library.js_interop) 'sha512_slowsinks.dart';
 import 'utils.dart';
 
 /// An implementation of the [SHA-384][rfc] hash function.


### PR DESCRIPTION
For web builds only `sha512_slowsinks.dart` is supported and `sha512_fastsinks.dart` is not supported. The conditional importing of `sha512_slowsinks.dart` uses `dart:js` instead of the [new js interop library](https://dart.dev/interop/js-interop) `dart:js_interop`, which does not work for WebAssembly builds. This change aligns us with the [recommended conditional import](https://dart.dev/interop/js-interop/package-web#conditional-imports) to differentiate between native and web.

https://github.com/dart-lang/core/issues/913
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.
</details>
