### PR TITLE
Add `separated`, `separatedList` and `separate` to iterables and lists.

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.20.0-wip
 
+- Adds `separated` and `separatedList` extension methods to `Iterable`.
+- Adds `separate` extension method to `List`
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using
   `Map.entries`.
 - Explicitly mark `BoolList` as `abstract interface`

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -56,6 +56,102 @@ extension IterableExtension<T> on Iterable<T> {
     return chosen;
   }
 
+  /// The elements of this iterable separated by [separator].
+  ///
+  /// Emits the same elements as this iterable, and also emits
+  /// a [separator] between any two of those elements.
+  ///
+  /// If [before] is set to `true`, a [separator] is also
+  /// emitted before the first element.
+  /// If [after] is set to `true`, a [separator] is also
+  /// emitted after the last element.
+  ///
+  /// If this iterable is empty, [before] and [after] have no effect.
+  ///
+  /// Example:
+  /// ```dart
+  /// print([1, 2, 3].separated(-1)); // (1, -1, 2, -1, 3)
+  /// print([1].separated(-1)); // (1)
+  /// print([].separated(-1)); // ()
+  ///
+  /// print([1, 2, 3].separated(
+  ///   -1
+  ///   before: true,
+  /// )); // (-1, 1, -1, 2, -1, 3)
+  ///
+  /// print([1].separated(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // (-1, 1, -1)
+  ///
+  /// print([].separated(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // ()
+  /// ```
+  Iterable<T> separated(T separator,
+      {bool before = false, bool after = false}) sync* {
+    const emitBefore = 1;
+    const emitAfter = 2;
+    var state = before ? emitBefore : 0;
+    final afterState = emitBefore | (after ? emitAfter : 0);
+    for (var element in this) {
+      if (state & emitBefore != 0) yield separator;
+      state = afterState;
+      yield element;
+    }
+    if (state & emitAfter != 0) yield separator;
+  }
+
+  /// Creates new list with the elements of this list separated by [separator].
+  ///
+  /// Returns a new list which contains the same elements as this list,
+  /// with a [separator] between any two of those elements.
+  ///
+  /// If [before] is set to `true`, a [separator] is also
+  /// added before the first element.
+  /// If [after] is set to `true`, a [separator] is also
+  /// added after the last element.
+  ///
+  /// If this list is empty, [before] and [after] have no effect.
+  ///
+  /// Example:
+  /// ```dart
+  /// print([1, 2, 3].separatedList(-1)); // [1, -1, 2, -1, 3]
+  /// print([1].separatedList(-1)); // [1]
+  /// print([].separatedList(-1)); // []
+  ///
+  /// print([1, 2, 3].separatedList(
+  ///   -1
+  ///   before: true,
+  /// )); // [-1, 1, -1, 2, -1, 3]
+  ///
+  /// print([1].separatedList(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // [-1, 1, -1]
+  ///
+  /// print([].separatedList(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // []
+  /// ```
+  List<T> separatedList(T separator,
+      {bool before = false, bool after = false}) {
+    var hasElement = false;
+    return [
+      for (var element in this) ...[
+        if (hasElement || (hasElement = true) && before) separator,
+        element,
+      ],
+      if (hasElement && after) separator
+    ];
+  }
+
   /// The elements that do not satisfy [test].
   Iterable<T> whereNot(bool Function(T element) test) =>
       where((element) => !test(element));

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -96,7 +96,7 @@ extension IterableExtension<T> on Iterable<T> {
           {bool before = false, bool after = false}) =>
       _SeparatedIterable<T>(this, separator, before, after);
 
-  /// Creates new list with the elements of this iterable separated by [separator].
+  /// Creates list with the elements of this iterable separated by [separator].
   ///
   /// Returns a new list which contains the same elements as this iterable,
   /// with a [separator] between any two of those elements.

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -96,9 +96,9 @@ extension IterableExtension<T> on Iterable<T> {
           {bool before = false, bool after = false}) =>
       _SeparatedIterable<T>(this, separator, before, after);
 
-  /// Creates new list with the elements of this list separated by [separator].
+  /// Creates new list with the elements of this iterable separated by [separator].
   ///
-  /// Returns a new list which contains the same elements as this list,
+  /// Returns a new list which contains the same elements as this iterable,
   /// with a [separator] between any two of those elements.
   ///
   /// If [before] is set to `true`, a [separator] is also
@@ -106,7 +106,7 @@ extension IterableExtension<T> on Iterable<T> {
   /// If [after] is set to `true`, a [separator] is also
   /// added after the last element.
   ///
-  /// If this list is empty, [before] and [after] have no effect.
+  /// If this iterable is empty, [before] and [after] have no effect.
   ///
   /// Example:
   /// ```dart

--- a/pkgs/collection/lib/src/iterable_extensions.dart
+++ b/pkgs/collection/lib/src/iterable_extensions.dart
@@ -75,34 +75,37 @@ extension IterableExtension<T> on Iterable<T> {
   /// print([].separated(-1)); // ()
   ///
   /// print([1, 2, 3].separated(
-  ///   -1
+  ///   -1,
   ///   before: true,
   /// )); // (-1, 1, -1, 2, -1, 3)
   ///
   /// print([1].separated(
-  ///   -1
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // (-1, 1, -1)
   ///
   /// print([].separated(
-  ///   -1
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // ()
   /// ```
   Iterable<T> separated(T separator,
       {bool before = false, bool after = false}) sync* {
-    const emitBefore = 1;
-    const emitAfter = 2;
-    var state = before ? emitBefore : 0;
-    final afterState = emitBefore | (after ? emitAfter : 0);
-    for (var element in this) {
-      if (state & emitBefore != 0) yield separator;
-      state = afterState;
-      yield element;
+    var iterator = this.iterator;
+    if (iterator.moveNext()) {
+      if (before) yield separator;
+      while (true) {
+        yield iterator.current;
+        if (iterator.moveNext()) {
+          yield separator;
+        } else {
+          break;
+        }
+      }
+      if (after) yield separator;
     }
-    if (state & emitAfter != 0) yield separator;
   }
 
   /// Creates new list with the elements of this list separated by [separator].
@@ -124,32 +127,39 @@ extension IterableExtension<T> on Iterable<T> {
   /// print([].separatedList(-1)); // []
   ///
   /// print([1, 2, 3].separatedList(
-  ///   -1
+  ///   -1,
   ///   before: true,
   /// )); // [-1, 1, -1, 2, -1, 3]
   ///
   /// print([1].separatedList(
-  ///   -1
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // [-1, 1, -1]
   ///
   /// print([].separatedList(
-  ///   -1
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // []
   /// ```
   List<T> separatedList(T separator,
       {bool before = false, bool after = false}) {
-    var hasElement = false;
-    return [
-      for (var element in this) ...[
-        if (hasElement || (hasElement = true) && before) separator,
-        element,
-      ],
-      if (hasElement && after) separator
-    ];
+    var result = <T>[];
+    var iterator = this.iterator;
+    if (iterator.moveNext()) {
+      if (before) result.add(separator);
+      while (true) {
+        result.add(iterator.current);
+        if (iterator.moveNext()) {
+          result.add(separator);
+        } else {
+          break;
+        }
+      }
+      if (after) result.add(separator);
+    }
+    return result;
   }
 
   /// The elements that do not satisfy [test].

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -390,23 +390,23 @@ extension ListExtensions<E> on List<E> {
   ///
   /// Example:
   /// ```dart
-  /// print([1, 2, 3]..insertSeparator(-1)); // [1, -1, 2, -1, 3]
-  /// print([1]..insertSeparator(-1)); // [1]
-  /// print([]..insertSeparator(-1)); // []
+  /// print([1, 2, 3]..separate(-1)); // [1, -1, 2, -1, 3]
+  /// print([1]..separate(-1)); // [1]
+  /// print([]..separate(-1)); // []
   ///
-  /// print([1, 2, 3]..insertSeparator(
-  ///   -1
+  /// print([1, 2, 3]..separate(
+  ///   -1,
   ///   before: true,
   /// )); // [-1, 1, -1, 2, -1, 3]
   ///
-  /// print([1]..insertSeparator(
-  ///   -1
+  /// print([1]..separate(
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // [-1, 1, -1]
   ///
-  /// print([]..insertSeparator(
-  ///   -1
+  /// print([]..separate(
+  ///   -1,
   ///   before: true,
   ///   after: true,
   /// )); // []
@@ -414,26 +414,34 @@ extension ListExtensions<E> on List<E> {
   void separate(E separator, {bool before = false, bool after = false}) {
     var length = this.length;
     if (length == 0) return;
-    var newLength = length * 2 - 1;
-    var offset = 0;
-    if (before) {
-      newLength++;
-      offset = 1;
-    }
-    if (after) newLength++;
-    E newElementAt(int index) {
-      index -= offset;
-      if (index.isOdd) return separator;
-      return this[index >> 1];
-    }
+    // New position of first element.
+    var newFirst = before ? 1 : 0;
+    // New position of last element.
+    var newLast = length * 2 - (newFirst ^ 1);
 
-    for (var i = length; i < newLength; i++) {
-      add(newElementAt(i));
+    var splitIndex = length - newFirst;
+    var cursor = splitIndex >> 1;
+    if (splitIndex.isEven) {
+      add(this[cursor]);
     }
-    for (var i = length, firstChanged = offset ^ 1; i > firstChanged;) {
-      --i;
-      this[i] = newElementAt(i);
+    cursor++;
+    while (this.length < newLast) {
+      add(separator);
+      add(this[cursor++]);
     }
+    assert(cursor == length);
+    if (after) add(separator);
+
+    cursor = splitIndex >> 1;
+    if (splitIndex.isOdd) {
+      this[--length] = this[cursor];
+    }
+    cursor--;
+    for (var i = length; i > 1;) {
+      this[--i] = separator;
+      this[--i] = this[cursor--];
+    }
+    if (newFirst != 0) this[0] = separator;
   }
 }
 

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -372,7 +372,7 @@ extension ListExtensions<E> on List<E> {
   ///   after: true,
   /// )); // []
   /// ```
-  /// @docImport 'iterable_extensions.dart' show IterableExtension;
+  /// @docImport 'iterable_extensions.dart';
   List<E> separated(E separator, {bool before = false, bool after = false}) =>
       _SeparatedList<E>(this, separator, before, after);
 

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -327,6 +327,114 @@ extension ListExtensions<E> on List<E> {
       yield slice(i, min(i + length, this.length));
     }
   }
+
+  /// Creates new list with the elements of this list separated by [separator].
+  ///
+  /// Returns a new list which contains the same elements as this list,
+  /// with a [separator] between any two of those elements.
+  ///
+  /// If [before] is set to `true`, a [separator] is also
+  /// added before the first element.
+  /// If [after] is set to `true`, a [separator] is also
+  /// added after the last element.
+  ///
+  /// If this list is empty, [before] and [after] have no effect.
+  ///
+  /// Example:
+  /// ```dart
+  /// print([1, 2, 3].separatedList(-1)); // [1, -1, 2, -1, 3]
+  /// print([1].separatedList(-1)); // [1]
+  /// print([].separatedList(-1)); // []
+  ///
+  /// print([1, 2, 3].separatedList(
+  ///   -1
+  ///   before: true,
+  /// )); // [-1, 1, -1, 2, -1, 3]
+  ///
+  /// print([1].separatedList(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // [-1, 1, -1]
+  ///
+  /// print([].separatedList(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // []
+  /// ```
+  List<E> separatedList(E separator,
+          {bool before = false, bool after = false}) =>
+      isEmpty
+          ? []
+          : [
+              if (!before) this[0],
+              for (var i = before ? 0 : 1; i < length; i++) ...[
+                separator,
+                this[i],
+              ],
+              if (after) separator
+            ];
+
+  /// Inserts [separator] between elements of this list.
+  ///
+  /// Afterwards, the list will contains all the original elements,
+  /// with a [separator] between any two of those elements.
+  ///
+  /// If [before] is set to `true`, a [separator] is also
+  /// inserted before the first element.
+  /// If [after] is set to `true`, a [separator] is also
+  /// added after the last element.
+  ///
+  /// If this list is empty, [before] and [after] have no effect.
+  ///
+  /// Example:
+  /// ```dart
+  /// print([1, 2, 3]..insertSeparator(-1)); // [1, -1, 2, -1, 3]
+  /// print([1]..insertSeparator(-1)); // [1]
+  /// print([]..insertSeparator(-1)); // []
+  ///
+  /// print([1, 2, 3]..insertSeparator(
+  ///   -1
+  ///   before: true,
+  /// )); // [-1, 1, -1, 2, -1, 3]
+  ///
+  /// print([1]..insertSeparator(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // [-1, 1, -1]
+  ///
+  /// print([]..insertSeparator(
+  ///   -1
+  ///   before: true,
+  ///   after: true,
+  /// )); // []
+  /// ```
+  void separate(E separator, {bool before = false, bool after = false}) {
+    var length = this.length;
+    if (length == 0) return;
+    var newLength = length * 2 - 1;
+    var offset = 0;
+    if (before) {
+      newLength++;
+      offset = 1;
+    }
+    if (after) newLength++;
+    E newElementAt(int index) {
+      index -= offset;
+      if (index.isOdd) return separator;
+      return this[index >> 1];
+    }
+
+    for (var i = length; i < newLength; i++) {
+      add(newElementAt(i));
+    }
+    for (var i = length, firstChanged = offset ^ 1; i > firstChanged;) {
+      --i;
+      this[i] = newElementAt(i);
+    }
+  }
 }
 
 /// Various extensions on lists of comparable elements.

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -343,7 +343,11 @@ extension ListExtensions<E> on List<E> {
   ///
   /// If this iterable is empty, [before] and [after] have no effect.
   ///
-  /// Compared to [IterableExtension.separatedList],
+  /// Compared to [IterableExtension.separatedList], this function
+  /// doesn't copy the elements into a new list, it creates a view
+  /// of the existing list with separators between the original elements.
+  /// To do that efficiently, the source must be a list, not just
+  /// an iterable.
   ///
   /// Example:
   /// ```dart
@@ -368,6 +372,7 @@ extension ListExtensions<E> on List<E> {
   ///   after: true,
   /// )); // []
   /// ```
+  /// @docImport 'iterable_extensions.dart' show IterableExtension;
   List<E> separated(E separator, {bool before = false, bool after = false}) =>
       _SeparatedList<E>(this, separator, before, after);
 

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -3,12 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Extension methods on common collection types.
+
 import 'dart:collection';
 import 'dart:math';
 
 import 'algorithms.dart';
 import 'algorithms.dart' as algorithms;
 import 'equality.dart';
+// For documentation only. Use docImport when reaching language version 3.8.
+import 'iterable_extensions.dart';
 import 'utils.dart';
 
 /// Various extensions on lists of arbitrary elements.
@@ -372,7 +375,6 @@ extension ListExtensions<E> on List<E> {
   ///   after: true,
   /// )); // []
   /// ```
-  /// @docImport 'iterable_extensions.dart';
   List<E> separated(E separator, {bool before = false, bool after = false}) =>
       _SeparatedList<E>(this, separator, before, after);
 

--- a/pkgs/collection/test/separate_extensions_test.dart
+++ b/pkgs/collection/test/separate_extensions_test.dart
@@ -1,0 +1,272 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Iterable.separated', () {
+    group('empty', () {
+      test('', () {
+        expect(iterable(<int>[]).separated(42), isEmpty);
+      });
+      test('before', () {
+        expect(iterable(<int>[]).separated(42, before: true), isEmpty);
+      });
+      test('after', () {
+        expect(iterable(<int>[]).separated(42, after: true), isEmpty);
+      });
+      test('before and after', () {
+        expect(iterable(<int>[]).separated(42, before: true, after: true),
+            isEmpty);
+      });
+      test('List', () {
+        var separatedList = <int>[].separated(42);
+        expect(separatedList, isNot(isA<List>()));
+        expect(separatedList, isEmpty);
+      });
+    });
+    group('Singleton', () {
+      test('', () {
+        expect(iterable(<int>[1]).separated(42), [1]);
+      });
+      test('before', () {
+        expect(iterable(<int>[1]).separated(42, before: true), [42, 1]);
+      });
+      test('after', () {
+        expect(iterable(<int>[1]).separated(42, after: true), [1, 42]);
+      });
+      test('before and after', () {
+        expect(iterable(<int>[1]).separated(42, before: true, after: true),
+            [42, 1, 42]);
+      });
+      test('List', () {
+        var separatedList = <int>[1].separated(42);
+        expect(separatedList, isNot(isA<List>()));
+        expect(separatedList, [1]);
+      });
+    });
+    group('Multiple', () {
+      test('', () {
+        expect(iterable(<int>[1, 2, 3]).separated(42), [1, 42, 2, 42, 3]);
+      });
+      test('before', () {
+        expect(iterable(<int>[1, 2, 3]).separated(42, before: true),
+            [42, 1, 42, 2, 42, 3]);
+      });
+      test('after', () {
+        expect(iterable(<int>[1, 2, 3]).separated(42, after: true),
+            [1, 42, 2, 42, 3, 42]);
+      });
+      test('before and after', () {
+        expect(
+            iterable(<int>[1, 2, 3]).separated(42, before: true, after: true),
+            [42, 1, 42, 2, 42, 3, 42]);
+      });
+      test('List', () {
+        var separatedList = <int>[1, 2, 3].separated(42);
+        expect(separatedList, isNot(isA<List>()));
+        expect(separatedList, [1, 42, 2, 42, 3]);
+      });
+    });
+    test('nulls', () {
+      expect(iterable<int?>([null, 2, null]).separated(null),
+          [null, null, 2, null, null]);
+    });
+    test('upcast receiver', () {
+      var source = <int>[1, 2, 3];
+      expect(iterable<num>(source).separated(3.14), [1, 3.14, 2, 3.14, 3]);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  group('Iterable.separatedList', () {
+    group('empty', () {
+      test('', () {
+        expect(iterable(<int>[]).separatedList(42), isEmpty);
+      });
+      test('before', () {
+        expect(iterable(<int>[]).separatedList(42, before: true), isEmpty);
+      });
+      test('after', () {
+        expect(iterable(<int>[]).separatedList(42, after: true), isEmpty);
+      });
+      test('before and after', () {
+        expect(iterable(<int>[]).separatedList(42, before: true, after: true),
+            isEmpty);
+      });
+    });
+    group('Singleton', () {
+      test('', () {
+        expect(iterable(<int>[1]).separatedList(42), [1]);
+      });
+      test('before', () {
+        expect(iterable(<int>[1]).separatedList(42, before: true), [42, 1]);
+      });
+      test('after', () {
+        expect(iterable(<int>[1]).separatedList(42, after: true), [1, 42]);
+      });
+      test('before and after', () {
+        expect(iterable(<int>[1]).separatedList(42, before: true, after: true),
+            [42, 1, 42]);
+      });
+    });
+    group('Multiple', () {
+      test('', () {
+        expect(iterable(<int>[1, 2, 3]).separatedList(42), [1, 42, 2, 42, 3]);
+      });
+      test('before', () {
+        expect(iterable(<int>[1, 2, 3]).separatedList(42, before: true),
+            [42, 1, 42, 2, 42, 3]);
+      });
+      test('after', () {
+        expect(iterable(<int>[1, 2, 3]).separatedList(42, after: true),
+            [1, 42, 2, 42, 3, 42]);
+      });
+      test('before and after', () {
+        expect(
+            iterable(<int>[1, 2, 3])
+                .separatedList(42, before: true, after: true),
+            [42, 1, 42, 2, 42, 3, 42]);
+      });
+    });
+    test('nulls', () {
+      expect(iterable<int?>([null, 2, null]).separatedList(null),
+          [null, null, 2, null, null]);
+    });
+    test('upcast receiver', () {
+      var source = <int>[1, 2, 3];
+      expect(iterable<num>(source).separatedList(3.14), [1, 3.14, 2, 3.14, 3]);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  group('List.separatedList', () {
+    group('empty', () {
+      test('', () {
+        expect(<int>[].separatedList(42), isEmpty);
+      });
+      test('before', () {
+        expect(<int>[].separatedList(42, before: true), isEmpty);
+      });
+      test('after', () {
+        expect(<int>[].separatedList(42, after: true), isEmpty);
+      });
+      test('before and after', () {
+        expect(<int>[].separatedList(42, before: true, after: true), isEmpty);
+      });
+    });
+    group('Singleton', () {
+      test('', () {
+        expect(<int>[1].separatedList(42), [1]);
+      });
+      test('before', () {
+        expect(<int>[1].separatedList(42, before: true), [42, 1]);
+      });
+      test('after', () {
+        expect(<int>[1].separatedList(42, after: true), [1, 42]);
+      });
+      test('before and after', () {
+        expect(
+            <int>[1].separatedList(42, before: true, after: true), [42, 1, 42]);
+      });
+    });
+    group('Multiple', () {
+      test('', () {
+        expect(<int>[1, 2, 3].separatedList(42), [1, 42, 2, 42, 3]);
+      });
+      test('before', () {
+        expect(<int>[1, 2, 3].separatedList(42, before: true),
+            [42, 1, 42, 2, 42, 3]);
+      });
+      test('after', () {
+        expect(<int>[1, 2, 3].separatedList(42, after: true),
+            [1, 42, 2, 42, 3, 42]);
+      });
+      test('before and after', () {
+        expect(<int>[1, 2, 3].separatedList(42, before: true, after: true),
+            [42, 1, 42, 2, 42, 3, 42]);
+      });
+    });
+    test('nulls', () {
+      expect([null, 2, null].separatedList(null), [null, null, 2, null, null]);
+    });
+    test('upcast receiver', () {
+      var source = <int>[1, 2, 3];
+      expect((source as List<num>).separatedList(3.14), [1, 3.14, 2, 3.14, 3]);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  group('List.separate', () {
+    group('empty', () {
+      test('', () {
+        expect(<int>[]..separate(42), isEmpty);
+      });
+      test('before', () {
+        expect(<int>[]..separate(42, before: true), isEmpty);
+      });
+      test('after', () {
+        expect(<int>[]..separate(42, after: true), isEmpty);
+      });
+      test('before and after', () {
+        expect(<int>[]..separate(42, before: true, after: true), isEmpty);
+      });
+    });
+    group('Singleton', () {
+      test('', () {
+        expect(<int>[1]..separate(42), [1]);
+      });
+      test('before', () {
+        expect(<int>[1]..separate(42, before: true), [42, 1]);
+      });
+      test('after', () {
+        expect(<int>[1]..separate(42, after: true), [1, 42]);
+      });
+      test('before and after', () {
+        expect(<int>[1]..separate(42, before: true, after: true), [42, 1, 42]);
+      });
+    });
+    group('Multiple', () {
+      test('', () {
+        expect(<int>[1, 2, 3]..separate(42), [1, 42, 2, 42, 3]);
+      });
+      test('before', () {
+        expect(
+            <int>[1, 2, 3]..separate(42, before: true), [42, 1, 42, 2, 42, 3]);
+      });
+      test('after', () {
+        expect(
+            <int>[1, 2, 3]..separate(42, after: true), [1, 42, 2, 42, 3, 42]);
+      });
+      test('before and after', () {
+        expect(<int>[1, 2, 3]..separate(42, before: true, after: true),
+            [42, 1, 42, 2, 42, 3, 42]);
+      });
+    });
+    test('nulls', () {
+      expect([null, 2, null]..separate(null), [null, null, 2, null, null]);
+    });
+    test('upcast receiver throws', () {
+      // Modifying the list is a contravariant operation,
+      // throws if separator is not valid.
+      var source = <int>[1, 2, 3];
+      expect(() => (source as List<num>).separate(3.14),
+          throwsA(isA<TypeError>()));
+    });
+    test('upcast receiver succeeds if separator valid', () {
+      // Modifying the list is a contravariant operation,
+      // succeeds if the separator is a valid value.
+      // (All operations are read/write with existing elements
+      // or the separator, which works when upcast if values are valid.)
+      var source = <int>[1, 2, 3];
+      expect((source as List<num>)..separate(42), [1, 42, 2, 42, 3]);
+    });
+  });
+}
+
+/// Creates a plain iterable not implementing any other class.
+Iterable<T> iterable<T>(Iterable<T> values) sync* {
+  yield* values;
+}

--- a/pkgs/collection/test/separate_extensions_test.dart
+++ b/pkgs/collection/test/separate_extensions_test.dart
@@ -229,20 +229,39 @@ void main() {
       });
     });
     group('Multiple', () {
-      test('', () {
-        expect(<int>[1, 2, 3]..separate(42), [1, 42, 2, 42, 3]);
+      group('odd length', () {
+        test('', () {
+          expect(<int>[1, 2, 3]..separate(42), [1, 42, 2, 42, 3]);
+        });
+        test('before', () {
+          expect(<int>[1, 2, 3]..separate(42, before: true),
+              [42, 1, 42, 2, 42, 3]);
+        });
+        test('after', () {
+          expect(
+              <int>[1, 2, 3]..separate(42, after: true), [1, 42, 2, 42, 3, 42]);
+        });
+        test('before and after', () {
+          expect(<int>[1, 2, 3]..separate(42, before: true, after: true),
+              [42, 1, 42, 2, 42, 3, 42]);
+        });
       });
-      test('before', () {
-        expect(
-            <int>[1, 2, 3]..separate(42, before: true), [42, 1, 42, 2, 42, 3]);
-      });
-      test('after', () {
-        expect(
-            <int>[1, 2, 3]..separate(42, after: true), [1, 42, 2, 42, 3, 42]);
-      });
-      test('before and after', () {
-        expect(<int>[1, 2, 3]..separate(42, before: true, after: true),
-            [42, 1, 42, 2, 42, 3, 42]);
+      group('even length', () {
+        test('', () {
+          expect(<int>[1, 2, 3, 4]..separate(42), [1, 42, 2, 42, 3, 42, 4]);
+        });
+        test('before', () {
+          expect(<int>[1, 2, 3, 4]..separate(42, before: true),
+              [42, 1, 42, 2, 42, 3, 42, 4]);
+        });
+        test('after', () {
+          expect(<int>[1, 2, 3, 4]..separate(42, after: true),
+              [1, 42, 2, 42, 3, 42, 4, 42]);
+        });
+        test('before and after', () {
+          expect(<int>[1, 2, 3, 4]..separate(42, before: true, after: true),
+              [42, 1, 42, 2, 42, 3, 42, 4, 42]);
+        });
       });
     });
     test('nulls', () {

--- a/pkgs/collection/test/separate_extensions_test.dart
+++ b/pkgs/collection/test/separate_extensions_test.dart
@@ -9,74 +9,152 @@ void main() {
   group('Iterable.separated', () {
     group('empty', () {
       test('', () {
-        expect(iterable(<int>[]).separated(42), isEmpty);
+        expectIterable(iterable(<int>[]).separated(42), <int>[]);
       });
       test('before', () {
-        expect(iterable(<int>[]).separated(42, before: true), isEmpty);
+        expectIterable(iterable(<int>[]).separated(42, before: true), <int>[]);
       });
       test('after', () {
-        expect(iterable(<int>[]).separated(42, after: true), isEmpty);
+        expectIterable(iterable(<int>[]).separated(42, after: true), <int>[]);
       });
       test('before and after', () {
-        expect(iterable(<int>[]).separated(42, before: true, after: true),
-            isEmpty);
+        expectIterable(
+            iterable(<int>[]).separated(42, before: true, after: true),
+            <int>[]);
       });
       test('List', () {
-        var separatedList = <int>[].separated(42);
+        var separatedList = iterable(<int>[]).separated(42);
         expect(separatedList, isNot(isA<List>()));
-        expect(separatedList, isEmpty);
+        expectIterable(separatedList, <int>[]);
       });
     });
     group('Singleton', () {
       test('', () {
-        expect(iterable(<int>[1]).separated(42), [1]);
+        expectIterable(iterable(<int>[1]).separated(42), [1]);
       });
       test('before', () {
-        expect(iterable(<int>[1]).separated(42, before: true), [42, 1]);
+        expectIterable(iterable(<int>[1]).separated(42, before: true), [42, 1]);
       });
       test('after', () {
-        expect(iterable(<int>[1]).separated(42, after: true), [1, 42]);
+        expectIterable(iterable(<int>[1]).separated(42, after: true), [1, 42]);
       });
       test('before and after', () {
-        expect(iterable(<int>[1]).separated(42, before: true, after: true),
+        expectIterable(
+            iterable(<int>[1]).separated(42, before: true, after: true),
             [42, 1, 42]);
       });
       test('List', () {
-        var separatedList = <int>[1].separated(42);
+        var separatedList = iterable(<int>[1]).separated(42);
         expect(separatedList, isNot(isA<List>()));
-        expect(separatedList, [1]);
+        expectIterable(separatedList, [1]);
       });
     });
     group('Multiple', () {
       test('', () {
-        expect(iterable(<int>[1, 2, 3]).separated(42), [1, 42, 2, 42, 3]);
+        expectIterable(
+            iterable(<int>[1, 2, 3]).separated(42), [1, 42, 2, 42, 3]);
       });
       test('before', () {
-        expect(iterable(<int>[1, 2, 3]).separated(42, before: true),
+        expectIterable(iterable(<int>[1, 2, 3]).separated(42, before: true),
             [42, 1, 42, 2, 42, 3]);
       });
       test('after', () {
-        expect(iterable(<int>[1, 2, 3]).separated(42, after: true),
+        expectIterable(iterable(<int>[1, 2, 3]).separated(42, after: true),
             [1, 42, 2, 42, 3, 42]);
       });
       test('before and after', () {
-        expect(
+        expectIterable(
             iterable(<int>[1, 2, 3]).separated(42, before: true, after: true),
             [42, 1, 42, 2, 42, 3, 42]);
       });
-      test('List', () {
-        var separatedList = <int>[1, 2, 3].separated(42);
-        expect(separatedList, isNot(isA<List>()));
-        expect(separatedList, [1, 42, 2, 42, 3]);
-      });
     });
     test('nulls', () {
-      expect(iterable<int?>([null, 2, null]).separated(null),
+      expectIterable(iterable<int?>([null, 2, null]).separated(null),
           [null, null, 2, null, null]);
     });
     test('upcast receiver', () {
       var source = <int>[1, 2, 3];
-      expect(iterable<num>(source).separated(3.14), [1, 3.14, 2, 3.14, 3]);
+      expectIterable(
+          iterable<num>(source).separated(3.14), [1, 3.14, 2, 3.14, 3]);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  group('List.separated', () {
+    group('empty', () {
+      test('', () {
+        expectUnmodifiableList(<int>[].separated(42), <int>[], 0);
+      });
+      test('before', () {
+        expectUnmodifiableList(<int>[].separated(42, before: true), <int>[], 0);
+      });
+      test('after', () {
+        expectUnmodifiableList(<int>[].separated(42, after: true), <int>[], 0);
+      });
+      test('before and after', () {
+        expectUnmodifiableList(
+            <int>[].separated(42, before: true, after: true), <int>[], 0);
+      });
+      test('List', () {
+        var separatedList = <int>[].separated(42);
+        expect(separatedList, isA<List>());
+        expectUnmodifiableList(separatedList, <int>[], 0);
+      });
+    });
+    group('Singleton', () {
+      test('', () {
+        expectUnmodifiableList(<int>[1].separated(42), [1], 0);
+      });
+      test('before', () {
+        expectUnmodifiableList(
+            <int>[1].separated(42, before: true), [42, 1], 0);
+      });
+      test('after', () {
+        expectUnmodifiableList(<int>[1].separated(42, after: true), [1, 42], 0);
+      });
+      test('before and after', () {
+        expectUnmodifiableList(
+            <int>[1].separated(42, before: true, after: true), [42, 1, 42], 0);
+      });
+      test('List', () {
+        var separatedList = <int>[1].separated(42);
+        expect(separatedList, isA<List>());
+        expectUnmodifiableList(separatedList, [1], 0);
+      });
+    });
+    group('Multiple', () {
+      test('', () {
+        expectUnmodifiableList(
+            <int>[1, 2, 3].separated(42), [1, 42, 2, 42, 3], 0);
+      });
+      test('before', () {
+        expectUnmodifiableList(<int>[1, 2, 3].separated(42, before: true),
+            [42, 1, 42, 2, 42, 3], 0);
+      });
+      test('after', () {
+        expectUnmodifiableList(<int>[1, 2, 3].separated(42, after: true),
+            [1, 42, 2, 42, 3, 42], 0);
+      });
+      test('before and after', () {
+        expectUnmodifiableList(
+            <int>[1, 2, 3].separated(42, before: true, after: true),
+            [42, 1, 42, 2, 42, 3, 42],
+            0);
+      });
+      test('List', () {
+        var separatedList = <int>[1, 2, 3].separated(42);
+        expect(separatedList, isA<List>());
+        expectUnmodifiableList(separatedList, [1, 42, 2, 42, 3], 0);
+      });
+    });
+    test('nulls', () {
+      expectUnmodifiableList(
+          [null, 2, null].separated(null), [null, null, 2, null, null], 0);
+    });
+    test('upcast receiver', () {
+      var source = <int>[1, 2, 3];
+      expectUnmodifiableList(
+          (source as List<num>).separated(3.14), [1, 3.14, 2, 3.14, 3], 0);
     });
   });
 
@@ -84,17 +162,17 @@ void main() {
   group('Iterable.separatedList', () {
     group('empty', () {
       test('', () {
-        expect(iterable(<int>[]).separatedList(42), isEmpty);
+        expect(iterable(<int>[]).separatedList(42), <int>[]);
       });
       test('before', () {
-        expect(iterable(<int>[]).separatedList(42, before: true), isEmpty);
+        expect(iterable(<int>[]).separatedList(42, before: true), <int>[]);
       });
       test('after', () {
-        expect(iterable(<int>[]).separatedList(42, after: true), isEmpty);
+        expect(iterable(<int>[]).separatedList(42, after: true), <int>[]);
       });
       test('before and after', () {
         expect(iterable(<int>[]).separatedList(42, before: true, after: true),
-            isEmpty);
+            <int>[]);
       });
     });
     group('Singleton', () {
@@ -145,16 +223,16 @@ void main() {
   group('List.separatedList', () {
     group('empty', () {
       test('', () {
-        expect(<int>[].separatedList(42), isEmpty);
+        expect(<int>[].separatedList(42), <int>[]);
       });
       test('before', () {
-        expect(<int>[].separatedList(42, before: true), isEmpty);
+        expect(<int>[].separatedList(42, before: true), <int>[]);
       });
       test('after', () {
-        expect(<int>[].separatedList(42, after: true), isEmpty);
+        expect(<int>[].separatedList(42, after: true), <int>[]);
       });
       test('before and after', () {
-        expect(<int>[].separatedList(42, before: true, after: true), isEmpty);
+        expect(<int>[].separatedList(42, before: true, after: true), <int>[]);
       });
     });
     group('Singleton', () {
@@ -202,70 +280,71 @@ void main() {
   group('List.separate', () {
     group('empty', () {
       test('', () {
-        expect(<int>[]..separate(42), isEmpty);
+        expectList(<int>[]..separate(42), <int>[]);
       });
       test('before', () {
-        expect(<int>[]..separate(42, before: true), isEmpty);
+        expectList(<int>[]..separate(42, before: true), <int>[]);
       });
       test('after', () {
-        expect(<int>[]..separate(42, after: true), isEmpty);
+        expectList(<int>[]..separate(42, after: true), <int>[]);
       });
       test('before and after', () {
-        expect(<int>[]..separate(42, before: true, after: true), isEmpty);
+        expectList(<int>[]..separate(42, before: true, after: true), <int>[]);
       });
     });
     group('Singleton', () {
       test('', () {
-        expect(<int>[1]..separate(42), [1]);
+        expectList(<int>[1]..separate(42), [1]);
       });
       test('before', () {
-        expect(<int>[1]..separate(42, before: true), [42, 1]);
+        expectList(<int>[1]..separate(42, before: true), [42, 1]);
       });
       test('after', () {
-        expect(<int>[1]..separate(42, after: true), [1, 42]);
+        expectList(<int>[1]..separate(42, after: true), [1, 42]);
       });
       test('before and after', () {
-        expect(<int>[1]..separate(42, before: true, after: true), [42, 1, 42]);
+        expectList(
+            <int>[1]..separate(42, before: true, after: true), [42, 1, 42]);
       });
     });
     group('Multiple', () {
       group('odd length', () {
         test('', () {
-          expect(<int>[1, 2, 3]..separate(42), [1, 42, 2, 42, 3]);
+          expectList(<int>[1, 2, 3]..separate(42), [1, 42, 2, 42, 3]);
         });
         test('before', () {
-          expect(<int>[1, 2, 3]..separate(42, before: true),
+          expectList(<int>[1, 2, 3]..separate(42, before: true),
               [42, 1, 42, 2, 42, 3]);
         });
         test('after', () {
-          expect(
+          expectList(
               <int>[1, 2, 3]..separate(42, after: true), [1, 42, 2, 42, 3, 42]);
         });
         test('before and after', () {
-          expect(<int>[1, 2, 3]..separate(42, before: true, after: true),
+          expectList(<int>[1, 2, 3]..separate(42, before: true, after: true),
               [42, 1, 42, 2, 42, 3, 42]);
         });
       });
       group('even length', () {
         test('', () {
-          expect(<int>[1, 2, 3, 4]..separate(42), [1, 42, 2, 42, 3, 42, 4]);
+          expectList(<int>[1, 2, 3, 4]..separate(42), [1, 42, 2, 42, 3, 42, 4]);
         });
         test('before', () {
-          expect(<int>[1, 2, 3, 4]..separate(42, before: true),
+          expectList(<int>[1, 2, 3, 4]..separate(42, before: true),
               [42, 1, 42, 2, 42, 3, 42, 4]);
         });
         test('after', () {
-          expect(<int>[1, 2, 3, 4]..separate(42, after: true),
+          expectList(<int>[1, 2, 3, 4]..separate(42, after: true),
               [1, 42, 2, 42, 3, 42, 4, 42]);
         });
         test('before and after', () {
-          expect(<int>[1, 2, 3, 4]..separate(42, before: true, after: true),
+          expectList(<int>[1, 2, 3, 4]..separate(42, before: true, after: true),
               [42, 1, 42, 2, 42, 3, 42, 4, 42]);
         });
       });
     });
     test('nulls', () {
-      expect([null, 2, null]..separate(null), [null, null, 2, null, null]);
+      expectList([null, 2, null]..separate(null), [null, null, 2, null, null]);
     });
     test('upcast receiver throws', () {
       // Modifying the list is a contravariant operation,
@@ -280,7 +359,7 @@ void main() {
       // (All operations are read/write with existing elements
       // or the separator, which works when upcast if values are valid.)
       var source = <int>[1, 2, 3];
-      expect((source as List<num>)..separate(42), [1, 42, 2, 42, 3]);
+      expectList((source as List<num>)..separate(42), [1, 42, 2, 42, 3]);
     });
   });
 }
@@ -288,4 +367,58 @@ void main() {
 /// Creates a plain iterable not implementing any other class.
 Iterable<T> iterable<T>(Iterable<T> values) sync* {
   yield* values;
+}
+
+void expectIterable<T>(Iterable<T> actual, List<T> expected) {
+  expect(actual, expected); // Elements are correct, uses `iterator`.
+
+  // Specialized members should work.
+  expect(actual.length, expected.length);
+  for (var i = 0; i < expected.length; i++) {
+    expect(actual.isEmpty, expected.isEmpty);
+    expect(actual.isNotEmpty, expected.isNotEmpty);
+    expect(actual.elementAt(i), expected[i]);
+    expect(actual.skip(i), expected.sublist(i));
+    expect(actual.take(i), expected.sublist(0, i));
+  }
+  expect(() => actual.elementAt(actual.length), throwsRangeError);
+  expect(() => actual.elementAt(-1), throwsRangeError);
+
+  if (expected.isNotEmpty) {
+    expect(actual.first, expected.first, reason: 'first');
+    expect(actual.last, expected.last, reason: 'last');
+  } else {
+    expect(() => actual.first, throwsStateError, reason: 'first');
+    expect(() => actual.last, throwsStateError, reason: 'last');
+  }
+}
+
+void expectList<T>(List<T> actual, List<T> expected) {
+  expectIterable(actual, expected);
+
+  for (var i = 0; i < expected.length; i++) {
+    expect(actual[i], expected[i]);
+  }
+  expect(() => actual[actual.length], throwsRangeError);
+  expect(() => actual[-1], throwsRangeError);
+}
+
+void expectUnmodifiableList<T>(List<T> actual, List<T> expected, T value) {
+  expectList(actual, expected);
+
+  expect(() => actual.length = 0, throwsUnsupportedError);
+  expect(() => actual.add(value), throwsUnsupportedError);
+  expect(() => actual.addAll([]), throwsUnsupportedError);
+  expect(() => actual.clear(), throwsUnsupportedError);
+  expect(() => actual.fillRange(0, 0, value), throwsUnsupportedError);
+  expect(() => actual.remove(0), throwsUnsupportedError);
+  expect(() => actual.removeAt(0), throwsUnsupportedError);
+  expect(() => actual.removeLast(), throwsUnsupportedError);
+  expect(() => actual.removeRange(0, 0), throwsUnsupportedError);
+  expect(() => actual.removeWhere((_) => false), throwsUnsupportedError);
+  expect(() => actual.replaceRange(0, 0, []), throwsUnsupportedError);
+  expect(() => actual.retainWhere((_) => true), throwsUnsupportedError);
+  expect(() => actual.setAll(0, []), throwsUnsupportedError);
+  expect(() => actual.setRange(0, 0, []), throwsUnsupportedError);
+  expect(() => actual.sort((a, b) => 0), throwsUnsupportedError);
 }


### PR DESCRIPTION
Each new function separates the elements of an iterable or list with a separator value of the same type.
They allow optionally adding the separator before a first element and/or after a last element.

* `separated`: Returns a (lazy) iterable backed by the original elements.
* `separatedList`: Creates an (eager) list with the same elements that separated would have returned. (But more efficiently.) (Also has a version specialized for a `List` input.)
* `separate`: Modifies a list in-place to add separators around the existing elements.

Fixes, among others, https://github.com/dart-lang/core/issues/628

This is one possible API. Names are fungible. Options are optional.

Attempts to give you the most direct API for what you want, so you don't have to create an intermediate iterable just to call `toList()` on it, and not call `toList()` if you could just modify the original list. 

WDYT?

