### PR TITLE
Add missing Int64.toDebugString for the native class

### DIFF
--- a/pkgs/fixnum/lib/src/int64_native.dart
+++ b/pkgs/fixnum/lib/src/int64_native.dart
@@ -357,6 +357,8 @@ class Int64 implements IntX {
 
   String toStringUnsigned() => _toRadixStringUnsigned(_i, 10);
 
+  String toDebugString() => 'Int64[_i=$_i]';
+
   static String _toRadixStringUnsigned(int value, int radix) {
     if (radix < 2 || radix > 36) {
       throw ArgumentError('toStringRadixUnsigned radix must be >= 2 and <= 36'


### PR DESCRIPTION
The emulated class has a `toDebugString` but the native class didn't.