### PR TITLE
collection: add move to ListExtensions

### DIFF
--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -270,6 +270,18 @@ extension ListExtensions<E> on List<E> {
     this[index2] = tmp;
   }
 
+  /// Move an element to the index of this list.
+  void move(int from, int to) {
+    RangeError.checkValidIndex(from, this, 'from');
+    RangeError.checkValidIndex(to, this, 'to');
+    if (from == to || from + 1 == to) return;
+    final element = removeAt(from);
+    if (from < to) {
+      to--;
+    }
+    insert(to, element);
+  }
+
   /// A fixed length view of a range of this list.
   ///
   /// The view is backed by this list, which must not change its length while

--- a/pkgs/collection/test/extensions_test.dart
+++ b/pkgs/collection/test/extensions_test.dart
@@ -1988,6 +1988,26 @@ void main() {
           expect([1, 2, 3]..swap(1, 0), [2, 1, 3]);
         });
       });
+      group('.move', () {
+        test('errors', () {
+          expect(() => [1].swap(0, 1), throwsArgumentError);
+          expect(() => [1, 2].swap(1, 2), throwsArgumentError);
+          expect(() => [1, 2].swap(2, 0), throwsArgumentError);
+          expect(() => [1].swap(-1, 0), throwsArgumentError);
+        });
+        test('self move', () {
+          expect([1]..move(0, 0), [1]);
+          expect([1, 2, 3]..move(1, 1), [1, 2, 3]);
+        });
+        test('actual move', () {
+          expect([1, 2, 3]..move(0, 2), [2, 1, 3]);
+          expect([1, 2, 3]..move(2, 0), [3, 1, 2]);
+          expect([1, 2, 3]..move(2, 1), [1, 3, 2]);
+          expect([1, 2, 3]..move(1, 2), [1, 2, 3]);
+          expect([1, 2, 3]..move(0, 1), [1, 2, 3]);
+          expect([1, 2, 3]..move(1, 0), [2, 1, 3]);
+        });
+      });
       group('.slice', () {
         test('errors', () {
           expect(() => [1].slice(-1, 1), throwsArgumentError);


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

There may be a reason this doesn’t already exist, but having this would be helpful.
