### PR TITLE
refactor(path): eliminate redundant validation

### DIFF
--- a/pkgs/path/CHANGELOG.md
+++ b/pkgs/path/CHANGELOG.md
@@ -7,6 +7,7 @@
   queries and fragments when when normalizing, include them 
   in/as the last segment when splitting.
 - Run `dart format` with the new style.
+- Centralize join logic in `Context` and eliminate redundant validation in `absolute()`.
 
 ## 1.9.1
 

--- a/pkgs/path/lib/src/context.dart
+++ b/pkgs/path/lib/src/context.dart
@@ -93,31 +93,28 @@ class Context {
     String? part14,
     String? part15,
   ]) {
-    _validateArgList('absolute', [
-      part1,
-      part2,
-      part3,
-      part4,
-      part5,
-      part6,
-      part7,
-      part8,
-      part9,
-      part10,
-      part11,
-      part12,
-      part13,
-      part14,
-      part15,
-    ]);
-
     // If there's a single absolute path, just return it. This is a lot faster
     // for the common case of `p.absolute(path)`.
-    if (part2 == null && isAbsolute(part1) && !isRootRelative(part1)) {
+    if (part2 == null &&
+        isAbsolute(part1) &&
+        !isRootRelative(part1) &&
+        part3 == null &&
+        part4 == null &&
+        part5 == null &&
+        part6 == null &&
+        part7 == null &&
+        part8 == null &&
+        part9 == null &&
+        part10 == null &&
+        part11 == null &&
+        part12 == null &&
+        part13 == null &&
+        part14 == null &&
+        part15 == null) {
       return part1;
     }
 
-    return join(
+    return _join('absolute', [
       current,
       part1,
       part2,
@@ -134,7 +131,7 @@ class Context {
       part13,
       part14,
       part15,
-    );
+    ]);
   }
 
   /// Gets the part of [path] after the last separator on the context's
@@ -282,26 +279,29 @@ class Context {
     String? part14,
     String? part15,
     String? part16,
-  ]) {
-    final parts = <String?>[
-      part1,
-      part2,
-      part3,
-      part4,
-      part5,
-      part6,
-      part7,
-      part8,
-      part9,
-      part10,
-      part11,
-      part12,
-      part13,
-      part14,
-      part15,
-      part16,
-    ];
-    _validateArgList('join', parts);
+  ]) =>
+      _join('join', [
+        part1,
+        part2,
+        part3,
+        part4,
+        part5,
+        part6,
+        part7,
+        part8,
+        part9,
+        part10,
+        part11,
+        part12,
+        part13,
+        part14,
+        part15,
+        part16,
+      ]);
+
+  /// Joins the given path parts into a single path.
+  String _join(String method, List<String?> parts) {
+    _validateArgList(method, parts);
     return joinAll(parts.whereType<String>());
   }
 

--- a/pkgs/path/test/posix_test.dart
+++ b/pkgs/path/test/posix_test.dart
@@ -751,6 +751,11 @@ void main() {
       );
       expect(context.absolute('a', r'\\b', 'c', 'd'), r'/root/path/a/\\b/c/d');
     });
+
+    test('disallows intermediate nulls', () {
+      expect(() => context.absolute('a', null, 'b'), throwsArgumentError);
+      expect(() => context.absolute('/a', null, 'b'), throwsArgumentError);
+    });
   });
 
   test('withoutExtension', () {

--- a/pkgs/path/test/url_test.dart
+++ b/pkgs/path/test/url_test.dart
@@ -1329,6 +1329,11 @@ void main() {
         r'https://dart.dev/root/path/a/\\b/c/d',
       );
     });
+
+    test('disallows intermediate nulls', () {
+      expect(() => context.absolute('a', null, 'b'), throwsArgumentError);
+      expect(() => context.absolute('/a', null, 'b'), throwsArgumentError);
+    });
   });
 
   test('withoutExtension', () {

--- a/pkgs/path/test/windows_test.dart
+++ b/pkgs/path/test/windows_test.dart
@@ -920,6 +920,11 @@ void main() {
       expect(context.absolute('a', r'c:\b', 'c', 'd'), r'c:\b\c\d');
       expect(context.absolute('a', r'\\b\c', r'\\d\e', 'f'), r'\\d\e\f');
     });
+
+    test('disallows intermediate nulls', () {
+      expect(() => context.absolute('a', null, 'b'), throwsArgumentError);
+      expect(() => context.absolute(r'C:\a', null, 'b'), throwsArgumentError);
+    });
   });
 
   test('withoutExtension', () {


### PR DESCRIPTION
Introduce a private `_join` helper to consolidate the path-joining logic used by `join()` and `absolute()`.

This refactoring:
- Eliminates redundant calls to `_validateArgList` in `absolute()`.
- Reduces intermediate list allocations by bypassing the public `join()` method when constructing absolute paths.
- Simplifies the maintenance of the fixed-parameter join signatures.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
