### PR TITLE
Add `ArgResult.flagCount`.

### DIFF
--- a/pkgs/args/CHANGELOG.md
+++ b/pkgs/args/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.9.0-wip
+
+* Adds `flagCount(name)` to `ArgResults` which returns the number of occurrences
+  of a flag. Allows, for example, `-vv` to represent "double verbose".
+
 ## 2.8.0
 
 * Allow designating a top-level command or a subcommand as a default one by

--- a/pkgs/args/lib/src/parser.dart
+++ b/pkgs/args/lib/src/parser.dart
@@ -124,6 +124,7 @@ class Parser {
     // Check if mandatory and invoke existing callbacks.
     _grammar.options.forEach((name, option) {
       var parsedOption = _results[name];
+      if (option.isFlag && parsedOption is int) parsedOption = parsedOption > 0;
 
       var callback = option.callback;
       if (callback == null) return;
@@ -374,11 +375,15 @@ class Parser {
     }
   }
 
-  /// Validates and stores [value] as the value for [option], which must be a
-  /// flag.
+  /// Validates and increases or resets the count for [option].
+  ///
+  /// If [value] is `false`, resets the option's value to zero.
+  /// If `true`, increases the count of occurrences of the [option],
+  /// which must be a flag.
   void _setFlag(Map results, Option option, bool value) {
     assert(option.isFlag);
-    results[option.name] = value;
+    results[option.name] =
+        value ? ((results[option.name] as int?) ?? 0) + 1 : 0;
   }
 
   /// Validates that [value] is allowed as a value of [option].

--- a/pkgs/args/pubspec.yaml
+++ b/pkgs/args/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.8.0
+version: 2.9.0-wip
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.

--- a/pkgs/args/test/parse_test.dart
+++ b/pkgs/args/test/parse_test.dart
@@ -90,6 +90,50 @@ void main() {
         var results = parser.parse(['--a']);
         throwsIllegalArg(() => results.multiOption('a'));
       });
+
+      test('flagCount', () {
+        var parser = ArgParser();
+        parser.addFlag('flag', abbr: 'f', defaultsTo: false, negatable: false);
+        parser.addFlag('negatable-flag', abbr: 'n', defaultsTo: false);
+
+        // Flags not occurring for testing default value.
+        parser.addFlag('default-true', abbr: 'd', defaultsTo: true);
+        parser.addFlag('default-false', defaultsTo: false);
+
+        var results = parser.parse([
+          '--flag',
+          '--negatable-flag',
+          '-f',
+          '-n',
+          '-fn',
+          '--no-negatable-flag', // Resets `-n` count
+          '-nf',
+          '-f',
+          '-n',
+          '--flag',
+          '--negatable-flag',
+        ]);
+
+        // Counts all occurrences.
+        expect(results.flagCount('flag'), 6);
+        expect(results.flag('flag'), true);
+
+        // Reset at `--no-negatable-flag`, only counts those after.
+        expect(results.flagCount('negatable-flag'), 3);
+        expect(results.flag('negatable-flag'), true);
+
+        expect(results.flagCount('default-true'), 1);
+        expect(results.flag('default-true'), true);
+
+        expect(results.flagCount('default-false'), 0);
+        expect(results.flag('default-false'), false);
+
+        // Reset works correctly as last occurrence,
+        // and doesn't fall back on default value.
+        results = parser.parse(['-d', '--no-default-true']);
+        expect(results.flagCount('default-true'), 0);
+        expect(results.flag('default-true'), false);
+      });
     });
 
     group('flag()', () {


### PR DESCRIPTION
Counts the occurrences of a flag, and makes it accessible in the `ArgResult`.

Only changes parser and result class, the `Option` class still treats flags as `bool` options, with a value that is `true` only when the count is greater than zero.

Fixes #937.

(The `-vv` is something I often use in my own scripts, and one reason for never using the `args` package.)