### PR TITLE
Add CI check to bump version on lint changes

### DIFF
--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -7,8 +7,6 @@
 # To learn more about customizing static analysis for your package or app,
 # visit https://dart.dev/tools/analysis.
 
-# Test
-
 include: package:lints/core.yaml
 
 linter:

--- a/pkgs/lints/pubspec.yaml
+++ b/pkgs/lints/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 7.0.0-wip
+version: 6.1.0
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.


### PR DESCRIPTION
We use a different process between `dart_flutter_team_lints` and `lints`
packages. Add a CI check that any change to lint sets files happens in a
`X.0.0` version.
