### PR TITLE
Remove sorting of subcommands

### DIFF
--- a/pkgs/args/CHANGELOG.md
+++ b/pkgs/args/CHANGELOG.md
@@ -6,6 +6,8 @@
   matches. This allows creating command line interfaces where both
   `program command` and `program command subcommand` are runnable
   (Fixes #103).
+* Remove sorting of the subcommands in usage output. Ordering will depend on the
+  order that `addSubCommand` is called.
 
 ## 2.7.0
 

--- a/pkgs/args/lib/command_runner.dart
+++ b/pkgs/args/lib/command_runner.dart
@@ -523,8 +523,8 @@ String _getCommandUsage(Map<String, Command> commands,
   var visible = names.where((name) => !commands[name]!.hidden);
   if (visible.isNotEmpty) names = visible;
 
-  // Show the commands alphabetically.
-  names = names.toList()..sort();
+  // Show names in the order they were first added
+  names = names.toList();
 
   // Group the commands by category.
   var commandsByCategory = SplayTreeMap<String, List<Command>>();

--- a/pkgs/args/test/command_runner_test.dart
+++ b/pkgs/args/test/command_runner_test.dart
@@ -265,8 +265,8 @@ information about a command.'''));
     });
 
     test('contains default command', () {
-      runner.addCommand(FooCommand());
       runner.addCommand(BarCommand(), isDefault: true);
+      runner.addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.

--- a/pkgs/args/test/command_test.dart
+++ b/pkgs/args/test/command_test.dart
@@ -156,8 +156,8 @@ Usage: test foo [<subcommand>] [arguments]
 -h, --help    Print this usage information.
 
 Available subcommands:
-  async   Set a value asynchronously.
   bar     (default) Set another value.
+  async   Set a value asynchronously.
 
 Default command (bar) will be selected if no command is explicitly specified.
 


### PR DESCRIPTION
Closes #901

The map will maintain key insertion order so the order of calls to
`addSubCommand` determines the output. It is unlikely there are
meaningful dependencies on the current alphabetical output behavior, but
some test which hardcoded expected usage output may be impacted - this
is not considered breaking for the args package.
