### PR TITLE
Fix extra newlines after separators

### DIFF
--- a/pkgs/args/CHANGELOG.md
+++ b/pkgs/args/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.8.0
+## 2.8.0-wip
 
 * Allow designating a top-level command or a subcommand as a default one by
   passing `isDefault: true` to `addCommand` or `addSubcommand`.
@@ -8,6 +8,7 @@
   (Fixes #103).
 * Remove sorting of the subcommands in usage output. Ordering will depend on the
   order that `addSubCommand` is called.
+* Remove extra newlines following separators when using flags without help text.
 
 ## 2.7.0
 

--- a/pkgs/args/lib/src/usage.dart
+++ b/pkgs/args/lib/src/usage.dart
@@ -81,6 +81,7 @@ class _Usage {
     if (_buffer.isNotEmpty) _buffer.write('\n\n');
     _buffer.write(separator);
     _newlinesNeeded = 1;
+    _currentColumn = 0;
   }
 
   void _writeOption(Option option) {

--- a/pkgs/args/pubspec.yaml
+++ b/pkgs/args/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.8.0
+version: 2.8.0-wip
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.

--- a/pkgs/args/test/usage_test.dart
+++ b/pkgs/args/test/usage_test.dart
@@ -455,6 +455,35 @@ void main() {
             --[no-]wombat    Third
             ''');
       });
+      test('consistently attaches separator headers to options', () {
+        var parser = ArgParser()
+          ..addSeparator('Group 1')
+          ..addFlag('flag-1')
+          ..addSeparator('Group 2 (follows no options with help)')
+          ..addFlag('flag-2', help: 'something')
+          ..addFlag('flag-3')
+          ..addSeparator('Group 3 (follows non-trailing option with help)')
+          ..addFlag('flag-4')
+          ..addFlag('flag-5', help: 'something')
+          ..addSeparator('Group 4 (follows trailing option with help)')
+          ..addFlag('flag-6');
+
+        validateUsage(parser, '''
+            Group 1
+            --[no-]flag-1    
+
+            Group 2 (follows no options with help)
+            --[no-]flag-2    something
+            --[no-]flag-3    
+
+            Group 3 (follows non-trailing option with help)
+            --[no-]flag-4    
+            --[no-]flag-5    something
+
+            Group 4 (follows trailing option with help)
+            --[no-]flag-6    
+            ''');
+      });
 
       test("doesn't add extra newlines after a multiline option", () {
         var parser = ArgParser();


### PR DESCRIPTION
Fixes #917

Reset the `_currentColumn` after writing separator lines and marking the
need for a newline.

Previously if a flag was written with no help text the current column
would remain at the position where help text would otherwise be written.
On the next write the target `column` would be lower so an extra line
is added to wrap back to the intended column.
