### PR TITLE
Fix is* OS getters on legacy fake platform

### DIFF
--- a/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
+++ b/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
@@ -11,7 +11,8 @@ import 'dart:convert' show JsonDecoder, JsonEncoder;
 
 import '../platforms_impl.dart'
     show BrowserPlatform, NativePlatform, Platform, PlatformTestBase;
-
+// ignore: invalid_use_of_visible_for_testing_member
+import '../testing/test_platforms.dart' show TestNativePlatform;
 // Not showing `lineTerminator` which wasn't used in the legacy code.
 import '../util/json_keys.dart'
     as json_key
@@ -56,6 +57,26 @@ final class FakePlatform extends PlatformTestBase {
   String? _localeName;
   @override
   String? packageConfig;
+
+  @override
+  // ignore: invalid_use_of_visible_for_testing_member
+  NativePlatform get nativePlatform => TestNativePlatform(
+    numberOfProcessors: _numberOfProcessors,
+    pathSeparator: _pathSeparator,
+    operatingSystem: _operatingSystem,
+    operatingSystemVersion: _operatingSystemVersion,
+    localHostname: _localHostname,
+    environment: _environment,
+    executable: _executable,
+    resolvedExecutable: _resolvedExecutable,
+    script: _script,
+    executableArguments: _executableArguments,
+    packageConfig: packageConfig,
+    version: _version,
+    stdinSupportsAnsi: _stdinSupportsAnsi,
+    stdoutSupportsAnsi: _stdoutSupportsAnsi,
+    localeName: _localeName,
+  );
 
   /// Creates a new legacy [FakePlatform] with the specified properties.
   ///

--- a/pkgs/platform/test/legacy/fake_platform_test.dart
+++ b/pkgs/platform/test/legacy/fake_platform_test.dart
@@ -122,6 +122,38 @@ void main() {
       });
     });
 
+    group('Handles is* OS checks', () {
+      test('matches isAndroid when operatingSystem is android', () {
+        final platform = FakePlatform(operatingSystem: 'android');
+        expect(platform.isAndroid, isTrue);
+      });
+
+      test('matches isIOS when operatingSystem is ios', () {
+        final platform = FakePlatform(operatingSystem: 'ios');
+        expect(platform.isIOS, isTrue);
+      });
+
+      test('matches isFuchsia when operatingSystem is fuchsia', () {
+        final platform = FakePlatform(operatingSystem: 'fuchsia');
+        expect(platform.isFuchsia, isTrue);
+      });
+
+      test('matches isMacOS when operatingSystem is macos', () {
+        final platform = FakePlatform(operatingSystem: 'macos');
+        expect(platform.isMacOS, isTrue);
+      });
+
+      test('matches isWindows when operatingSystem is windows', () {
+        final platform = FakePlatform(operatingSystem: 'windows');
+        expect(platform.isWindows, isTrue);
+      });
+
+      test('isLinux is false when operatingSystem is windows', () {
+        final platform = FakePlatform(operatingSystem: 'windows');
+        expect(platform.isLinux, isFalse);
+      });
+    });
+
     group('json', () {
       test('fromJson', () {
         final json = io.File('test/legacy/platform.json').readAsStringSync();


### PR DESCRIPTION
Corrects the behavior of the fields like `isAndroid` when the fake
platform is constructed with `operatingSystem: 'android'`. Existing
tests rely on this behavior.
