### PR TITLE
Generalize binarySearchBy and lowerBoundBy to accept K key instead of E value

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.20.0-wip
 
+- Generalize `binarySearchBy` and `lowerBoundBy` to accept a key of type `K`
+  directly instead of a list element of type `E`. This allows searching a
+  `List<E>` sorted by a key field using a standalone key value without
+  constructing a full `E` object.
+
 - Adds `separated` and `separatedList` extension methods to `Iterable`.
 - Adds `separate` extension method to `List`
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using

--- a/pkgs/collection/lib/src/algorithms.dart
+++ b/pkgs/collection/lib/src/algorithms.dart
@@ -27,12 +27,12 @@ int binarySearch<E>(
   return binarySearchBy<E, E>(sortedList, identity, compare, value);
 }
 
-/// Returns a position of the [value] in [sortedList], if it is there.
+/// Returns a position of the [key] in [sortedList], if it is there.
 ///
 /// If the list isn't sorted according to the [compare] function on the [keyOf]
 /// property of the elements, the result is unpredictable.
 ///
-/// Returns -1 if [value] is not in the list by default.
+/// Returns -1 if [key] is not in the list by default.
 ///
 /// If [start] and [end] are supplied, only that range is searched,
 /// and only that range need to be sorted.
@@ -40,14 +40,13 @@ int binarySearchBy<E, K>(
   List<E> sortedList,
   K Function(E element) keyOf,
   int Function(K, K) compare,
-  E value, [
+  K key, [
   int start = 0,
   int? end,
 ]) {
   end = RangeError.checkValidRange(start, end, sortedList.length);
   var min = start;
   var max = end;
-  var key = keyOf(value);
   while (min < max) {
     var mid = min + ((max - min) >> 1);
     var element = sortedList[mid];
@@ -80,9 +79,9 @@ int lowerBound<E>(List<E> sortedList, E value, {int Function(E, E)? compare}) {
   return lowerBoundBy<E, E>(sortedList, identity, compare, value);
 }
 
-/// Returns the first position in [sortedList] that is not before [value].
+/// Returns the first position in [sortedList] that is not before [key].
 ///
-/// Uses binary search to find the location of [value].
+/// Uses binary search to find the location of [key].
 /// This takes on the order of `log(n)` comparisons.
 /// Elements are compared using the [compare] function of the [keyOf] property
 /// of the elements.
@@ -90,7 +89,7 @@ int lowerBound<E>(List<E> sortedList, E value, {int Function(E, E)? compare}) {
 /// unpredictable.
 ///
 /// Returns the length of [sortedList] if all the items in [sortedList] are
-/// before [value].
+/// before [key].
 ///
 /// If [start] and [end] are supplied, only that range is searched,
 /// and only that range need to be sorted.
@@ -98,14 +97,13 @@ int lowerBoundBy<E, K>(
   List<E> sortedList,
   K Function(E element) keyOf,
   int Function(K, K) compare,
-  E value, [
+  K key, [
   int start = 0,
   int? end,
 ]) {
   end = RangeError.checkValidRange(start, end, sortedList.length);
   var min = start;
   var max = end;
-  var key = keyOf(value);
   while (min < max) {
     var mid = min + ((max - min) >> 1);
     var element = sortedList[mid];

--- a/pkgs/collection/lib/src/list_extensions.dart
+++ b/pkgs/collection/lib/src/list_extensions.dart
@@ -49,7 +49,7 @@ extension ListExtensions<E> on List<E> {
         this,
         keyOf,
         compare,
-        element,
+        keyOf(element),
         start,
         end,
       );
@@ -75,7 +75,7 @@ extension ListExtensions<E> on List<E> {
         this,
         keyOf,
         (a, b) => a.compareTo(b),
-        element,
+        keyOf(element),
         start,
         end,
       );
@@ -117,7 +117,7 @@ extension ListExtensions<E> on List<E> {
     int start = 0,
     int? end,
   ]) =>
-      algorithms.lowerBoundBy(this, keyOf, compare, element, start, end);
+      algorithms.lowerBoundBy(this, keyOf, compare, keyOf(element), start, end);
 
   /// Returns the index where [element] should be in this sorted list.
   ///
@@ -145,7 +145,7 @@ extension ListExtensions<E> on List<E> {
         this,
         keyOf,
         compareComparable,
-        element,
+        keyOf(element),
         start,
         end,
       );

--- a/pkgs/collection/test/algorithms_test.dart
+++ b/pkgs/collection/test/algorithms_test.dart
@@ -163,6 +163,47 @@ void main() {
     expect(lowerBound(l2, C(5), compare: compareC), equals(1));
   });
 
+  // Tests for binarySearchBy with K key (different type from E).
+  test('binsearchBy - search by key of different type', () {
+    var list = [C(0), C(5), C(10)];
+    // Search using int key directly instead of C object.
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, -1), equals(-1));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 0), equals(0));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 2), equals(-1));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 5), equals(1));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 7), equals(-1));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 10), equals(2));
+    expect(binarySearchBy(list, (c) => c.id, (a, b) => a - b, 12), equals(-1));
+  });
+
+  test('binsearchBy - empty list', () {
+    expect(binarySearchBy(<C>[], (c) => c.id, (a, b) => a - b, 5), equals(-1));
+  });
+
+  // Tests for lowerBoundBy with K key (different type from E).
+  test('lowerboundBy - search by key of different type', () {
+    var list = [C(0), C(5), C(10)];
+    // Search using int key directly instead of C object.
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, -1), equals(0));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 0), equals(0));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 2), equals(1));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 5), equals(1));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 7), equals(2));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 10), equals(2));
+    expect(lowerBoundBy(list, (c) => c.id, (a, b) => a - b, 12), equals(3));
+  });
+
+  test('lowerboundBy - empty list', () {
+    expect(lowerBoundBy(<C>[], (c) => c.id, (a, b) => a - b, 5), equals(0));
+  });
+
+  test('lowerboundBy - repeat keys', () {
+    var l1 = [C(5), C(5), C(5)];
+    var l2 = [C(0), C(5), C(5), C(5), C(10)];
+    expect(lowerBoundBy(l1, (c) => c.id, (a, b) => a - b, 5), equals(0));
+    expect(lowerBoundBy(l2, (c) => c.id, (a, b) => a - b, 5), equals(1));
+  });
+
   void testSort(
     String name,
     void Function(List<int> elements, [int? start, int? end]) sort,


### PR DESCRIPTION
Fixes #895

Previously, `binarySearchBy` and `lowerBoundBy` required passing a full
list element of type `E`, which forced callers to construct a dummy object
just to search by a key field. For example, searching a `List<Result>`
sorted by a `String name` field required creating a `Result` with only
the name populated.

Now both functions accept a key of type `K` directly, matching the type
returned by the `keyOf` function. This enables natural use cases like:

```dart
binarySearchBy(results, (r) => r.name, (a, b) => a.compareTo(b), 'foo');
