### PR TITLE
fix(crypto): avoid parameter reassignment in Hmac constructor

### DIFF
--- a/pkgs/crypto/CHANGELOG.md
+++ b/pkgs/crypto/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.8-wip
 
 - Drop unused `pkg:typed_data` dependency.
+- Work-around [dart-lang/sdk#63747](https://github.com/dart-lang/sdk/issues/63747).
 
 ## 3.0.7
 

--- a/pkgs/crypto/lib/src/hmac.dart
+++ b/pkgs/crypto/lib/src/hmac.dart
@@ -30,11 +30,12 @@ class Hmac extends Converter<List<int>, Digest> {
       : _hash = hash,
         _key = Uint8List(hash.blockSize) {
     // Hash the key if it's longer than the block size of the hash.
-    if (key.length > _hash.blockSize) key = _hash.convert(key).bytes;
+    final keyBytes =
+        key.length > _hash.blockSize ? _hash.convert(key).bytes : key;
 
     // If [key] is shorter than the block size, the rest of [_key] will be
     // 0-padded.
-    _key.setRange(0, key.length, key);
+    _key.setRange(0, keyBytes.length, keyBytes);
   }
 
   @override


### PR DESCRIPTION
Avoid reassigning the mutable parameter `key` inside the `Hmac` constructor.
This works around a `dart2wasm` compiler bug in the dev SDK where mutating
parameter variables can lead to specialized types in Wasm locals causing
a `RuntimeError: unreachable` runtime crash.

Workaround for https://github.com/dart-lang/sdk/issues/63747
