### PR TITLE
Enable changelog updates in groundskeeper workflow

### DIFF
--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -32,4 +32,6 @@ jobs:
       directory: pkgs/${{ matrix.package }}
       branch: auto-tidy-${{ matrix.package }}
       title: 'Tidy: package:${{ matrix.package }}'
+      update-changelog: true
+      changelog-message: 'Automated formatting and fixes.'
     secrets: inherit


### PR DESCRIPTION
Ported changes from labs groundskeeper workflow to enable changelog updates with a default message.