### PR TITLE
Add `isLinux` etc. to `Platform` as instance members.

### DIFF
--- a/pkgs/platform/CHANGELOG.md
+++ b/pkgs/platform/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 * New non-backwards compatible API.
   Use `Platform.current` to access the current platform,
-  and `Platform.current.native` to either get access to native
+  and `Platform.current.nativePlatform` to either get access to native
   platform information, or get a `null` on non-native platforms.
-  Similarly `Platform.current.web` is only non-`null` on the web.
+  Similarly `Platform.current.browserPlatform` is only non-`null` on the web.
 
   Mocking APIs are moved to a separate library to ensure they are
   only used for testing, and to allow better performance in production.

--- a/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
+++ b/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
@@ -7,7 +7,6 @@
 @Deprecated('Import package:platform/testing.dart for testing')
 library;
 
-import 'dart:async';
 import 'dart:convert' show JsonDecoder, JsonEncoder;
 
 import '../platform_apis.dart'

--- a/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
+++ b/pkgs/platform/lib/src/legacy_implementation/legacy_classes.dart
@@ -7,10 +7,12 @@
 @Deprecated('Import package:platform/testing.dart for testing')
 library;
 
+import 'dart:async';
 import 'dart:convert' show JsonDecoder, JsonEncoder;
 
 import '../platform_apis.dart'
     show BrowserPlatform, NativePlatform, Platform, PlatformBase;
+import '../platforms.dart' show PlatformIsOSMixin;
 // ignore: invalid_use_of_visible_for_testing_member
 import '../testing/test_platforms.dart' show TestNativePlatform;
 
@@ -41,7 +43,7 @@ import '../util/json_keys.dart'
 /// > the non-deprecated API, and use `TestNativePlatform` to
 /// > give custom values to native platform properties.
 @Deprecated('Use TestNativePlatform instead')
-final class FakePlatform extends PlatformBase {
+final class FakePlatform extends PlatformBase with PlatformIsOSMixin {
   // ignore: invalid_use_of_visible_for_testing_member
   final TestNativePlatform _nativePlatform;
 
@@ -257,7 +259,7 @@ final class FakePlatform extends PlatformBase {
 }
 
 @Deprecated('Use NativePlatform.current! instead')
-final class LocalPlatform extends PlatformBase {
+final class LocalPlatform extends PlatformBase with PlatformIsOSMixin {
   static const _instance = LocalPlatform._();
   @Deprecated('Use NativePlatform.current! instead')
   const factory LocalPlatform() = _LocalPlatformInstance;

--- a/pkgs/platform/lib/src/platform_apis.dart
+++ b/pkgs/platform/lib/src/platform_apis.dart
@@ -7,7 +7,6 @@
 // ignore: unnecessary_library_name - Used by DartDoc
 library platform_apis;
 
-import '../testing.dart';
 import 'legacy_implementation/legacy_platform_members.dart'
     show LegacyPlatformMembers;
 import 'platform_specific/unknown_platform.dart'

--- a/pkgs/platform/lib/src/platform_apis.dart
+++ b/pkgs/platform/lib/src/platform_apis.dart
@@ -7,6 +7,7 @@
 // ignore: unnecessary_library_name - Used by DartDoc
 library platform_apis;
 
+import '../testing.dart';
 import 'legacy_implementation/legacy_platform_members.dart'
     show LegacyPlatformMembers;
 import 'platform_specific/unknown_platform.dart'
@@ -14,6 +15,7 @@ import 'platform_specific/unknown_platform.dart'
     if (dart.library.js_interop) 'platform_specific/web_platform.dart'
     as impl
     show platformInstance;
+import 'platforms.dart' show PlatformIsOSMembers;
 import 'testing/zone_overrides.dart' as overrides;
 
 /// Dart runtime platform information.
@@ -26,7 +28,9 @@ import 'testing/zone_overrides.dart' as overrides;
 ///
 /// If running in a browser, the [browserPlatform] objects is
 /// non-`null` and provides information about the browser.
-abstract final class Platform with LegacyPlatformMembers {
+abstract final class Platform
+    with LegacyPlatformMembers
+    implements PlatformIsOSMembers {
   /// The current [Platform] information of the running program.
   @pragma('dart2js:prefer-inline')
   static Platform get current =>

--- a/pkgs/platform/lib/src/platform_specific/io_platform.dart
+++ b/pkgs/platform/lib/src/platform_specific/io_platform.dart
@@ -7,13 +7,14 @@
 library platform_impl;
 
 import '../platform_apis.dart' as apis;
+import '../platforms.dart' show PlatformIsOSMixin;
 import 'io_native_platform.dart';
 
 const Platform platformInstance = Platform._();
 
 /// Native (`dart:io`-based) implementation of [apis.Platform] and
 /// [apis.NativePlatform].
-final class Platform extends apis.PlatformBase {
+final class Platform extends apis.PlatformBase with PlatformIsOSMixin {
   /// The current native platform, if running on a native platform.
   @pragma('vm:prefer-inline')
   @override

--- a/pkgs/platform/lib/src/platform_specific/unknown_platform.dart
+++ b/pkgs/platform/lib/src/platform_specific/unknown_platform.dart
@@ -8,11 +8,12 @@
 library platform_impl;
 
 import '../platform_apis.dart' as apis;
+import '../platforms.dart' show PlatformIsOSMixin;
 
 const platformInstance = Platform._();
 
 /// Non-web, non-native Platform implementation.
-final class Platform extends apis.PlatformBase {
+final class Platform extends apis.PlatformBase with PlatformIsOSMixin {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   @override

--- a/pkgs/platform/lib/src/platform_specific/web_platform.dart
+++ b/pkgs/platform/lib/src/platform_specific/web_platform.dart
@@ -9,6 +9,7 @@
 library platform_impl;
 
 import '../platform_apis.dart' as apis;
+import '../platforms.dart' show PlatformIsOSMixin;
 import 'web_browser_platform.dart';
 
 const Platform platformInstance = Platform._();
@@ -16,7 +17,7 @@ const Platform platformInstance = Platform._();
 /// Web/JS based implementation of [apis.Platform].
 ///
 /// Uses [BrowserPlatform] to implement [apis.BrowserPlatform].
-final class Platform extends apis.PlatformBase {
+final class Platform extends apis.PlatformBase with PlatformIsOSMixin {
   /// The current native platform, if running on a native platform.
   @override
   @pragma('dart2js:prefer-inline')

--- a/pkgs/platform/lib/src/platforms.dart
+++ b/pkgs/platform/lib/src/platforms.dart
@@ -10,7 +10,7 @@
 // ignore: unnecessary_library_name - Used by DartDoc
 library exported_platforms;
 
-import 'platform_apis.dart' show Platform;
+import 'platform_apis.dart' show NativePlatform, Platform, PlatformBase;
 export 'platform_apis.dart' show BrowserPlatform, NativePlatform, Platform;
 
 /// Shorthands for checking operating system on the native platform.
@@ -18,34 +18,101 @@ export 'platform_apis.dart' show BrowserPlatform, NativePlatform, Platform;
 /// Extension getters on `Platform` which forward to the operating system
 /// checks on [Platform.nativePlatform], after checking that this is a native
 /// platform.
+///
+/// Not currently directly callabke because [Platform] has instance members
+/// with  the same behavior, but may become useful if those can be removed
 extension PlatformIsOS on Platform {
   /// Whether this is a [nativePlatform] with [NativePlatform.isAndroid].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isAndroid => nativePlatform?.isAndroid ?? false;
+  bool get isAndroid =>
+      nativePlatform?.operatingSystem == NativePlatform.android;
 
   /// Whether this is a [nativePlatform] with [NativePlatform.isFuchsia].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isFuchsia => nativePlatform?.isFuchsia ?? false;
+  bool get isFuchsia =>
+      nativePlatform?.operatingSystem == NativePlatform.fuchsia;
 
   /// Whether this is a [nativePlatform] with [NativePlatform.isIOS].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isIOS => nativePlatform?.isIOS ?? false;
+  bool get isIOS => nativePlatform?.operatingSystem == NativePlatform.iOS;
 
   /// Whether this is a [nativePlatform] with [NativePlatform.isLinux].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isLinux => nativePlatform?.isLinux ?? false;
+  bool get isLinux => nativePlatform?.operatingSystem == NativePlatform.linux;
 
   /// Whether this is a [nativePlatform] with [NativePlatform.isMacOS].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isMacOS => nativePlatform?.isMacOS ?? false;
+  bool get isMacOS => nativePlatform?.operatingSystem == NativePlatform.macOS;
 
   /// Whether this is a [nativePlatform] with [NativePlatform.isWindows].
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
-  bool get isWindows => nativePlatform?.isWindows ?? false;
+  bool get isWindows =>
+      nativePlatform?.operatingSystem == NativePlatform.windows;
+}
+
+// TODO: Eventually get rid of these members on `Platform`.
+// Maybe even on `NativePlatform`, and let `NativePlatform.operatingSystem`
+// string interpretation be handled by client libraries, so this
+// library doesn't have to hardwire specific operating system names.
+
+base mixin PlatformIsOSMixin on PlatformBase implements PlatformIsOSMembers {
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isAndroid => PlatformIsOS(this).isAndroid;
+
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isFuchsia => PlatformIsOS(this).isFuchsia;
+
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isIOS => PlatformIsOS(this).isIOS;
+
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isLinux => PlatformIsOS(this).isLinux;
+
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isMacOS => PlatformIsOS(this).isMacOS;
+
+  @override
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  bool get isWindows => PlatformIsOS(this).isWindows;
+}
+
+// The interface for the members of [PlatformIsOSMixin] implemented by
+// [Platform].
+//
+// Kept here so it can be deprecated at some point.
+abstract interface class PlatformIsOSMembers {
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isAndroid].
+  bool get isAndroid;
+
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isFuchsia].
+  bool get isFuchsia;
+
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isIOS].
+  bool get isIOS;
+
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isLinux].
+  bool get isLinux;
+
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isMacOS].
+  bool get isMacOS;
+
+  /// Whether a [Platform.nativePlatform] with [NativePlatform.isWindows].
+  bool get isWindows;
 }

--- a/pkgs/platform/lib/src/testing/test_platforms.dart
+++ b/pkgs/platform/lib/src/testing/test_platforms.dart
@@ -15,6 +15,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 
 import '../platform_apis.dart';
+import '../platforms.dart' show PlatformIsOSMixin;
 import '../util/json_keys.dart' as json_key;
 import 'zone_overrides.dart' as overrides;
 
@@ -23,7 +24,7 @@ import 'zone_overrides.dart' as overrides;
 /// Implements [Platform], but allows a [TestBrowserPlatform] or
 /// [TestNativePlatform] to be the non-`null` platform object.
 @visibleForTesting
-final class TestPlatform extends PlatformBase {
+final class TestPlatform extends PlatformBase with PlatformIsOSMixin {
   /// The current native platform, if running on a native platform.
   @override
   final TestNativePlatform? nativePlatform;


### PR DESCRIPTION
Avoids be breaking for code that receives a `Platform` without importing the library itself, and which does `.isLinux`. Such code won't see the extension members, so it's not backwards compatible enough.
