### PR TITLE
Port `pairs` extension from dart-archive/collection#289

### DIFF
--- a/pkgs/collection/CHANGELOG.md
+++ b/pkgs/collection/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.20.0-wip
 
+- Adds `Map.pairs` extension method to make it easier to work with maps using records rather than MapEntry.
 - Adds `separated` and `separatedList` extension methods to `Iterable`.
 - Adds `separate` extension method to `List`
 - Add `IterableMapEntryExtension` for working on `Map` as a list of pairs, using

--- a/pkgs/collection/lib/collection.dart
+++ b/pkgs/collection/lib/collection.dart
@@ -17,6 +17,7 @@ export 'src/functions.dart';
 export 'src/iterable_extensions.dart';
 export 'src/iterable_zip.dart';
 export 'src/list_extensions.dart';
+export 'src/map_extensions.dart';
 export 'src/priority_queue.dart';
 export 'src/queue_list.dart';
 export 'src/union_set.dart';

--- a/pkgs/collection/lib/src/map_extensions.dart
+++ b/pkgs/collection/lib/src/map_extensions.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+extension MapExtensions<K, V> on Map<K, V> {
+  /// Like [Map.entries], but returns each entry as a record instead of a [MapEntry].
+  Iterable<(K, V)> get pairs => entries.map((entry) => (entry.key, entry.value));
+}

--- a/pkgs/collection/test/extensions_test.dart
+++ b/pkgs/collection/test/extensions_test.dart
@@ -2393,6 +2393,19 @@ void main() {
       });
     });
   });
+
+  group('Map', () {
+    group('pairs', () {
+      test('returns an empty list for an empty map', () {
+        expect(const <int, int>{}.pairs, isEmpty);
+      });
+
+      test('returns a pair for every entry in the map', () {
+        expect(const {1: 2, 3: 4, 5: 6}.pairs,
+            equals(const [(1, 2), (3, 4), (5, 6)]));
+      });
+    });
+  });
 }
 
 /// Creates a plain iterable not implementing any other class.


### PR DESCRIPTION
This ports the `pairs` extension from dart-archive/collection#289.

The original implementation was approved but got derailed by rollup attempts that included a major version bump and breaking changes (dart-archive/collection#284 and dart-lang/core#859). Those PRs have been in limbo for years and are unlikely to ever be merged.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
