### PR TITLE
[path] Strip Windows Extended-Length Path prefixes in absolutePathToUri

### DIFF
--- a/pkgs/path/CHANGELOG.md
+++ b/pkgs/path/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.9.2-wip
 
+- `WindowsStyle.absolutePathToUri` (and therefore `toUri()`) now strips Windows
+  Extended-Length Path prefixes (`\\?\` and `\\?\UNC\`) instead of
+  throwing a `FormatException`. This aligns `path.toUri()` with
+  `Uri.file()` / `Uri.directory()` from `dart:io`.
 - Make `Url` style better at recognizing schemes and authorities.
   Only consider a path as being a schemed URL if it starts with a
   valid scheme.

--- a/pkgs/path/lib/src/style/windows.dart
+++ b/pkgs/path/lib/src/style/windows.dart
@@ -103,6 +103,24 @@ class WindowsStyle extends InternalStyle {
 
   @override
   Uri absolutePathToUri(String path) {
+    // Strip Windows Extended-Length Path prefixes so that `toUri()` aligns
+    // with `Uri.file()` / `Uri.directory()` from `dart:io`.
+    //
+    // `\\?\C:\path`           -> `C:\path`
+    // `\\?\UNC\server\share` -> `\\server\share`
+    //
+    // The `\\?\` prefix is a Win32 API artifact (enables paths > 260 chars
+    // and disables DOS device-name interpretation). It is not user intent and
+    // should not leak into the resulting file URI. See:
+    // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
+    if (path.startsWith(r'\\?\')) {
+      if (path.startsWith(r'\\?\UNC\')) {
+        path = r'\\' + path.substring(8);
+      } else {
+        path = path.substring(4);
+      }
+    }
+
     final parsed = ParsedPath.parse(path, this);
     if (parsed.root!.startsWith(r'\\')) {
       // Network paths become "file://server/share/path/to/file".
@@ -119,10 +137,7 @@ class WindowsStyle extends InternalStyle {
       }
 
       return Uri(
-        scheme: 'file',
-        host: rootParts.first,
-        pathSegments: parsed.parts,
-      );
+          scheme: 'file', host: rootParts.first, pathSegments: parsed.parts);
     } else {
       // Drive-letter paths become "file:///C:/path/to/file".
 
@@ -136,10 +151,8 @@ class WindowsStyle extends InternalStyle {
 
       // Get rid of the trailing "\" in "C:\" because the URI constructor will
       // add a separator on its own.
-      parsed.parts.insert(
-        0,
-        parsed.root!.replaceAll('/', '').replaceAll('\\', ''),
-      );
+      parsed.parts
+          .insert(0, parsed.root!.replaceAll('/', '').replaceAll('\\', ''));
 
       return Uri(scheme: 'file', pathSegments: parsed.parts);
     }

--- a/pkgs/path/lib/src/style/windows.dart
+++ b/pkgs/path/lib/src/style/windows.dart
@@ -114,10 +114,10 @@ class WindowsStyle extends InternalStyle {
     // should not leak into the resulting file URI. See:
     // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
     if (path.startsWith(r'\\?\')) {
-      if (path.startsWith(r'\\?\UNC\')) {
-        path = r'\\' + path.substring(8);
+      if (path.startsWith(r'UNC\', r'\\?\'.length)) {
+        path = path.replaceRange(0, r'\\?\UNC'.length, r'\');
       } else {
-        path = path.substring(4);
+        path = path.substring(r'\\?\'.length);
       }
     }
 

--- a/pkgs/path/test/windows_test.dart
+++ b/pkgs/path/test/windows_test.dart
@@ -1058,6 +1058,31 @@ void main() {
       Uri.parse('_%7B_%7D_%60_%5E_%20_%22_%25_'),
     );
     expect(context.toUri(''), Uri.parse(''));
+
+    // Windows Extended-Length Path prefixes are stripped to align with
+    // `Uri.file()` from `dart:io`. See:
+    // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces
+    expect(
+      context.toUri(r'\\?\UNC\server\share\path\to\foo'),
+      Uri.parse('file://server/share/path/to/foo'),
+    );
+    expect(
+      context.toUri(r'\\?\UNC\wsl.localhost\Ubuntu-24.04\tmp\foo'),
+      Uri.parse('file://wsl.localhost/Ubuntu-24.04/tmp/foo'),
+    );
+    expect(
+      context.toUri(r'\\?\UNC\server\share'),
+      Uri.parse('file://server/share'),
+    );
+    expect(
+      context.toUri(r'\\?\UNC\server\share\'),
+      Uri.parse('file://server/share/'),
+    );
+    expect(
+      context.toUri(r'\\?\C:\path\to\foo'),
+      Uri.parse('file:///C:/path/to/foo'),
+    );
+    expect(context.toUri(r'\\?\C:\'), Uri.parse('file:///C:/'));
   });
 
   group('prettyUri', () {


### PR DESCRIPTION
## Problem

`WindowsStyle.absolutePathToUri` (and therefore `toUri()`) throws `FormatException` when given Windows Extended-Length Path prefixes:

- `\\?\C:\long\path`
- `\\?\UNC\server\share\path`

These prefixes are documented in [Win32 File Namespaces](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces) and are increasingly common because:

1. `GetFinalPathNameByHandle` always returns the `\\?\UNC\` form for any UNC path
2. WSL paths (`\\wsl.localhost\<distro>\...`) hit this format whenever Windows APIs normalize them
3. Paths exceeding `MAX_PATH` (260 chars) require the `\\?\` prefix

### Repro

```dart
import 'package:path/path.dart' as p;

void main() {
  // Works fine — Uri.file() strips the prefix
  print(Uri.file(r'\\?\UNC\wsl.localhost\Ubuntu-24.04\tmp\foo'));
  // → file://wsl.localhost/Ubuntu-24.04/tmp/foo

  // Throws FormatException — path.toUri() does not strip the prefix
  print(p.toUri(r'\\?\UNC\wsl.localhost\Ubuntu-24.04\tmp\foo'));
  // → FormatException: Illegal character in path
}
```

### Root cause

`absolutePathToUri` does not strip the `\\?\` prefix before parsing. `ParsedPath.parse` then misinterprets `\\?\UNC` as a UNC root with `?` as the server name, which is not a valid URI host — causing `FormatException` when passed to the `Uri` constructor.

This makes `path.toUri()` inconsistent with `Uri.file()` / `Uri.directory()` from `dart:io`, which already handle these prefixes correctly.

## Fix

Strip the Win32 Extended-Length Path prefix at the entry of `absolutePathToUri`, before any parsing:

- `\\?\UNC\server\share\...` → `\\server\share\...` (strip `\\?\UNC\`, prepend `\\`)
- `\\?\C:\path\...` → `C:\path\...` (strip `\\?\`)

This aligns `path.toUri()` with `Uri.file()` — the `\\?\` prefix is a Win32 API artifact (enables paths > 260 chars and disables DOS device-name interpretation), not user intent, and should not leak into the resulting file URI.

Discussed in #980 — @lrhn confirmed the direction: *"Maybe we just need to see what `Uri.fromFile` does, and copy that."*

## Tests

Added 6 test cases to `pkgs/path/test/windows_test.dart` covering:

| Input | Expected URI |
|-------|-------------|
| `\\?\UNC\server\share\path\to\foo` | `file://server/share/path/to/foo` |
| `\\?\UNC\wsl.localhost\Ubuntu-24.04\tmp\foo` | `file://wsl.localhost/Ubuntu-24.04/tmp/foo` |
| `\\?\UNC\server\share` | `file://server/share` |
| `\\?\UNC\server\share\` | `file://server/share/` |
| `\\?\C:\path\to\foo` | `file:///C:/path/to/foo` |
| `\\?\C:\` | `file:///C:/` |

All existing tests + 6 new tests pass (68 total in `windows_test.dart`). `dart analyze` reports no issues.

## Scope

This PR intentionally only fixes `absolutePathToUri` (the function reported in #980). Other methods like `rootLength` / `split` may also benefit from prefix stripping, but those are out of scope for this focused fix.

Fixes #980
