### PR TITLE
Pin actions/checkout

### DIFF
--- a/.github/workflows/lints_version_bump.yaml
+++ b/.github/workflows/lints_version_bump.yaml
@@ -10,7 +10,7 @@ jobs:
   check-major-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Verify Major first in major version is X.0.0 or X.0.0-wip
         if: "!contains(github.event.pull_request.labels.*.name, 'skip-breaking-check')"

--- a/.github/workflows/lints_version_bump.yaml
+++ b/.github/workflows/lints_version_bump.yaml
@@ -1,4 +1,5 @@
 name: Enforce Major Version for lint changes
+permissions: read-all
 
 on:
   pull_request:


### PR DESCRIPTION
Pins `actions/checkout` in `lints_version_bump.yaml` to commit SHA `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`.