### PR TITLE
Replace permissions: read-all with permissions: contents: read in workflows

### DIFF
--- a/.github/workflows/args.yaml
+++ b/.github/workflows/args.yaml
@@ -1,5 +1,6 @@
 name: package:args
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -57,6 +60,8 @@ jobs:
         sdk: ['3.3', dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/async.yaml
+++ b/.github/workflows/async.yaml
@@ -1,5 +1,6 @@
 name: package:async
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run on PRs and pushes to the default branch.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/characters.yaml
+++ b/.github/workflows/characters.yaml
@@ -1,5 +1,6 @@
 name: package:characters
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev, stable, 3.4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -57,6 +60,8 @@ jobs:
         sdk: [dev, stable, 3.4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/collection.yaml
+++ b/.github/workflows/collection.yaml
@@ -1,5 +1,6 @@
 name: package:collection
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -1,5 +1,6 @@
 name: package:convert
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/crypto.yaml
+++ b/.github/workflows/crypto.yaml
@@ -1,5 +1,6 @@
 name: package:crypto
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/fixnum.yaml
+++ b/.github/workflows/fixnum.yaml
@@ -1,5 +1,6 @@
 name: package:fixnum
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [3.4.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.4.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/groundskeeper.yml
+++ b/.github/workflows/groundskeeper.yml
@@ -1,4 +1,6 @@
 name: Groundskeeper
+permissions:
+  contents: read
 
 on:
   schedule:
@@ -27,9 +29,9 @@ jobs:
           - path
           - platform
           - typed_data
-    uses: dart-lang/ecosystem/.github/workflows/groundskeeper.yml@main
+    uses: dart-lang/ecosystem/.github/workflows/groundskeeper.yml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       directory: pkgs/${{ matrix.package }}
       branch: auto-tidy-${{ matrix.package }}
       title: 'Tidy: package:${{ matrix.package }}'
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,4 +1,7 @@
 name: Health
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]
@@ -6,7 +9,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       ignore_coverage: "**.mock.dart,**.g.dart"
       ignore_license: "**.mock.dart,**.g.dart,**.mocks.dart,pkgs/platform/*"

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -1,5 +1,6 @@
 name: package:lints
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -30,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/lints_version_bump.yaml
+++ b/.github/workflows/lints_version_bump.yaml
@@ -1,5 +1,6 @@
 name: Enforce Major Version for lint changes
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -12,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: Verify Major first in major version is X.0.0 or X.0.0-wip
         if: "!contains(github.event.pull_request.labels.*.name, 'skip-breaking-check')"

--- a/.github/workflows/logging.yaml
+++ b/.github/workflows/logging.yaml
@@ -1,5 +1,6 @@
 name: package:logging
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -30,6 +31,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -55,6 +58,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/os_detect.yaml
+++ b/.github/workflows/os_detect.yaml
@@ -1,5 +1,6 @@
 name: package:os_detect
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.5, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/path.yaml
+++ b/.github/workflows/path.yaml
@@ -1,5 +1,6 @@
 name: package:path
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -53,6 +56,8 @@ jobs:
         sdk: [3.4, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/platform.yaml
+++ b/.github/workflows/platform.yaml
@@ -1,5 +1,6 @@
 name: package:platform
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -25,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: dev
@@ -42,6 +45,8 @@ jobs:
         sdk: [stable, beta, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,9 +1,11 @@
 name: Comment on the pull request
+permissions:
+  contents: read
 
 on:
   # Trigger this workflow after the Health workflow completes. This workflow will have permissions to
   # do things like create comments on the PR, even if the original workflow couldn't.
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: 
       - Publish
       - Health
@@ -12,6 +14,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@edfdb3b4063b9034b708144633a700204f865f43
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 # A CI configuration to auto-publish pub packages.
 
 name: Publish
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -11,7 +13,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@edfdb3b4063b9034b708144633a700204f865f43
     with:
       sdk: beta
       write-comments: false

--- a/.github/workflows/pull_request_label.yaml
+++ b/.github/workflows/pull_request_label.yaml
@@ -5,7 +5,8 @@
 # https://github.com/actions/labeler.
 
 name: Pull Request Labeler
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request_target

--- a/.github/workflows/typed_data.yaml
+++ b/.github/workflows/typed_data.yaml
@@ -1,5 +1,6 @@
 name: package:typed_data
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
@@ -31,6 +32,8 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}
@@ -58,6 +61,8 @@ jobs:
         sdk: [3.5, dev]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: ${{ matrix.sdk }}


### PR DESCRIPTION
Replacing top-level `permissions: read-all` with least-privilege `permissions: contents: read` in GitHub Actions workflows to avoid excessive-permissions warnings from zizmor scans (which warns on both `read-all` and missing permissions blocks).