### PR TITLE
Add new lints

### DIFF
--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -7,12 +7,14 @@
   - added [simple_directive_paths] (https://github.com/dart-lang/core/issues/978)
   - added [simplify_variable_pattern] (https://github.com/dart-lang/core/issues/954)
   - added [unnecessary_unawaited] (https://github.com/dart-lang/core/issues/954)
+  - added [future_sync_value] (https://github.com/dart-lang/core/issues/976)
 
 [var_with_no_type_annotation]: https://dart.dev/lints/var_with_no_type_annotation
 [switch_on_type]: https://dart.dev/lints/switch_on_type
 [simple_directive_paths]: https://dart.dev/lints/simple_directive_paths
 [simplify_variable_pattern]: https://dart.dev/lints/simplify_variable_pattern
 [unnecessary_unawaited]: https://dart.dev/lints/unnecessary_unawaited
+[future_sync_value]: https://dart.dev/tools/diagnostics/future_sync_value
 
 ## 6.1.0
 

--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -1,14 +1,12 @@
 ## 7.0.0-wip
 
 - `core`:
-  - added [var_with_no_type_annotation] (https://github.com/dart-lang/core/issues/955)
   - added [switch_on_type] (https://github.com/dart-lang/core/issues/954)
 - `recommended`:
   - added [simple_directive_paths] (https://github.com/dart-lang/core/issues/978)
   - added [simplify_variable_pattern] (https://github.com/dart-lang/core/issues/954)
   - added [unnecessary_unawaited] (https://github.com/dart-lang/core/issues/954)
 
-[var_with_no_type_annotation]: https://dart.dev/lints/var_with_no_type_annotation
 [switch_on_type]: https://dart.dev/lints/switch_on_type
 [simple_directive_paths]: https://dart.dev/lints/simple_directive_paths
 [simplify_variable_pattern]: https://dart.dev/lints/simplify_variable_pattern

--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -1,4 +1,18 @@
-## 6.1.1-wip
+## 7.0.0-wip
+
+- `core`:
+  - added [var_with_no_type_annotation] (https://github.com/dart-lang/core/issues/955)
+  - added [switch_on_type] (https://github.com/dart-lang/core/issues/954)
+- `recommended`:
+  - added [simple_directive_paths] (https://github.com/dart-lang/core/issues/978)
+  - added [simplify_variable_pattern] (https://github.com/dart-lang/core/issues/954)
+  - added [unnecessary_unawaited] (https://github.com/dart-lang/core/issues/954)
+
+[var_with_no_type_annotation]: https://dart.dev/lints/var_with_no_type_annotation
+[switch_on_type]: https://dart.dev/lints/switch_on_type
+[simple_directive_paths]: https://dart.dev/lints/simple_directive_paths
+[simplify_variable_pattern]: https://dart.dev/lints/simplify_variable_pattern
+[unnecessary_unawaited]: https://dart.dev/lints/unnecessary_unawaited
 
 ## 6.1.0
 

--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -7,14 +7,12 @@
   - added [simple_directive_paths] (https://github.com/dart-lang/core/issues/978)
   - added [simplify_variable_pattern] (https://github.com/dart-lang/core/issues/954)
   - added [unnecessary_unawaited] (https://github.com/dart-lang/core/issues/954)
-  - added [future_sync_value] (https://github.com/dart-lang/core/issues/976)
 
 [var_with_no_type_annotation]: https://dart.dev/lints/var_with_no_type_annotation
 [switch_on_type]: https://dart.dev/lints/switch_on_type
 [simple_directive_paths]: https://dart.dev/lints/simple_directive_paths
 [simplify_variable_pattern]: https://dart.dev/lints/simplify_variable_pattern
 [unnecessary_unawaited]: https://dart.dev/lints/unnecessary_unawaited
-[future_sync_value]: https://dart.dev/tools/diagnostics/future_sync_value
 
 ## 6.1.0
 

--- a/pkgs/lints/lib/core.yaml
+++ b/pkgs/lints/lib/core.yaml
@@ -34,10 +34,12 @@ linter:
     - provide_deprecation_message
     - secure_pubspec_urls
     - strict_top_level_inference
+    - switch_on_type
     - type_literal_in_constant_pattern
     - unintended_html_in_doc_comment
     - unnecessary_overrides
     - unrelated_type_equality_checks
     - use_string_in_part_of_directives
     - valid_regexps
+    - var_with_no_type_annotation
     - void_checks

--- a/pkgs/lints/lib/core.yaml
+++ b/pkgs/lints/lib/core.yaml
@@ -41,5 +41,4 @@ linter:
     - unrelated_type_equality_checks
     - use_string_in_part_of_directives
     - valid_regexps
-    - var_with_no_type_annotation
     - void_checks

--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -47,6 +47,8 @@ linter:
     - prefer_null_aware_operators
     - prefer_spread_collections
     - recursive_getters
+    - simple_directive_paths
+    - simplify_variable_pattern
     - slash_for_doc_comments
     - type_init_formals
     - unnecessary_brace_in_string_interps

--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -65,6 +65,7 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
+    - unnecessary_unawaited
     - unnecessary_underscores
     - use_function_type_syntax_for_parameters
     - use_null_aware_elements

--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -23,7 +23,6 @@ linter:
     - empty_constructor_bodies
     - empty_statements
     - exhaustive_cases
-    - future_sync_value
     - implementation_imports
     - invalid_runtime_check_with_js_interop_types
     - library_prefixes

--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -23,6 +23,7 @@ linter:
     - empty_constructor_bodies
     - empty_statements
     - exhaustive_cases
+    - future_sync_value
     - implementation_imports
     - invalid_runtime_check_with_js_interop_types
     - library_prefixes

--- a/pkgs/lints/pubspec.yaml
+++ b/pkgs/lints/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lints
-version: 6.1.1-wip
+version: 7.0.0-wip
 description: >
   Official Dart lint rules. Defines the 'core' and 'recommended' set of lints
   suggested by the Dart team.
@@ -11,7 +11,7 @@ topics:
   - lints
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.12.0
 
 # NOTE: Code is not allowed in this package - do not add dependencies.
 # dependencies:

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -33,12 +33,14 @@
 | [`provide_deprecation_message`](https://dart.dev/lints/provide_deprecation_message) | Provide a deprecation message, via `@Deprecated("message")`. |  |
 | [`secure_pubspec_urls`](https://dart.dev/lints/secure_pubspec_urls) | Use secure urls in `pubspec.yaml`. |  |
 | [`strict_top_level_inference`](https://dart.dev/lints/strict_top_level_inference) | Specify type annotations. | ✅ |
+| [`switch_on_type`](https://dart.dev/lints/switch_on_type) | Avoid switch statements on a 'Type'. |  |
 | [`type_literal_in_constant_pattern`](https://dart.dev/lints/type_literal_in_constant_pattern) | Don't use constant patterns with type literals. | ✅ |
 | [`unintended_html_in_doc_comment`](https://dart.dev/lints/unintended_html_in_doc_comment) | Use of angle brackets in a doc comment is treated as HTML by Markdown. |  |
 | [`unnecessary_overrides`](https://dart.dev/lints/unnecessary_overrides) | Don't override a method to do a super method invocation with the same parameters. | ✅ |
-| [`unrelated_type_equality_checks`](https://dart.dev/lints/unrelated_type_equality_checks) | Equality operator `==` invocation with references of unrelated types. |  |
+| [`unrelated_type_equality_checks`](https://dart.dev/lints/unrelated_type_equality_checks) | Equality operator `==` invocation with references of unrelated types. | ✅ |
 | [`use_string_in_part_of_directives`](https://dart.dev/lints/use_string_in_part_of_directives) | Use string in part of directives. | ✅ |
 | [`valid_regexps`](https://dart.dev/lints/valid_regexps) | Use valid regular expression syntax. |  |
+| [`var_with_no_type_annotation`](https://dart.dev/lints/var_with_no_type_annotation) | Avoid declaring parameters with `var` and no type annotation. | ✅ |
 | [`void_checks`](https://dart.dev/lints/void_checks) | Don't assign to `void`. |  |
 <!-- core -->
 
@@ -83,6 +85,8 @@
 | [`prefer_null_aware_operators`](https://dart.dev/lints/prefer_null_aware_operators) | Prefer using `null`-aware operators. | ✅ |
 | [`prefer_spread_collections`](https://dart.dev/lints/prefer_spread_collections) | Use spread collections when possible. | ✅ |
 | [`recursive_getters`](https://dart.dev/lints/recursive_getters) | Property getter recursively returns itself. |  |
+| [`simple_directive_paths`](https://dart.dev/lints/simple_directive_paths) | Use simple directive paths. | ✅ |
+| [`simplify_variable_pattern`](https://dart.dev/lints/simplify_variable_pattern) | Avoid unnecessary member names in variable patterns. | ✅ |
 | [`slash_for_doc_comments`](https://dart.dev/lints/slash_for_doc_comments) | Prefer using `///` for doc comments. | ✅ |
 | [`type_init_formals`](https://dart.dev/lints/type_init_formals) | Don't type annotate initializing formals. | ✅ |
 | [`unnecessary_brace_in_string_interps`](https://dart.dev/lints/unnecessary_brace_in_string_interps) | Avoid using braces in interpolation when not needed. | ✅ |
@@ -99,6 +103,7 @@
 | [`unnecessary_string_interpolations`](https://dart.dev/lints/unnecessary_string_interpolations) | Unnecessary string interpolation. | ✅ |
 | [`unnecessary_this`](https://dart.dev/lints/unnecessary_this) | Don't access members with `this` unless avoiding shadowing. | ✅ |
 | [`unnecessary_to_list_in_spreads`](https://dart.dev/lints/unnecessary_to_list_in_spreads) | Unnecessary `toList()` in spreads. | ✅ |
+| [`unnecessary_unawaited`](https://dart.dev/lints/unnecessary_unawaited) | Unnecessary use of 'unawaited'. | ✅ |
 | [`unnecessary_underscores`](https://dart.dev/lints/unnecessary_underscores) | Unnecessary underscores can be removed. | ✅ |
 | [`use_function_type_syntax_for_parameters`](https://dart.dev/lints/use_function_type_syntax_for_parameters) | Use generic function type syntax for parameters. | ✅ |
 | [`use_null_aware_elements`](https://dart.dev/lints/use_null_aware_elements) | If-elements testing for null can be replaced with null-aware elements. | ✅ |

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -40,7 +40,6 @@
 | [`unrelated_type_equality_checks`](https://dart.dev/lints/unrelated_type_equality_checks) | Equality operator `==` invocation with references of unrelated types. | ✅ |
 | [`use_string_in_part_of_directives`](https://dart.dev/lints/use_string_in_part_of_directives) | Use string in part of directives. | ✅ |
 | [`valid_regexps`](https://dart.dev/lints/valid_regexps) | Use valid regular expression syntax. |  |
-| [`var_with_no_type_annotation`](https://dart.dev/lints/var_with_no_type_annotation) | Avoid declaring parameters with `var` and no type annotation. | ✅ |
 | [`void_checks`](https://dart.dev/lints/void_checks) | Don't assign to `void`. |  |
 <!-- core -->
 

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -61,7 +61,6 @@
 | [`empty_constructor_bodies`](https://dart.dev/lints/empty_constructor_bodies) | Use `;` instead of `{}` for empty constructor bodies. | ✅ |
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
 | [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
-| [`future_sync_value`](https://dart.dev/lints/future_sync_value) |  |  |
 | [`implementation_imports`](https://dart.dev/lints/implementation_imports) | Don't import implementation files from another package. |  |
 | [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types) | Avoid runtime type tests with JS interop types where the result may not be platform-consistent. |  |
 | [`library_prefixes`](https://dart.dev/lints/library_prefixes) | Use `lowercase_with_underscores` when specifying a library prefix. |  |

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -61,6 +61,7 @@
 | [`empty_constructor_bodies`](https://dart.dev/lints/empty_constructor_bodies) | Use `;` instead of `{}` for empty constructor bodies. | ✅ |
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
 | [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
+| [`future_sync_value`](https://dart.dev/lints/future_sync_value) |  |  |
 | [`implementation_imports`](https://dart.dev/lints/implementation_imports) | Don't import implementation files from another package. |  |
 | [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types) | Avoid runtime type tests with JS interop types where the result may not be platform-consistent. |  |
 | [`library_prefixes`](https://dart.dev/lints/library_prefixes) | Use `lowercase_with_underscores` when specifying a library prefix. |  |

--- a/pkgs/lints/tool/rules.json
+++ b/pkgs/lints/tool/rules.json
@@ -40,6 +40,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "async_return_with_no_await",
+    "description": "Return with no await.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "avoid_annotating_with_dynamic",
     "description": "Avoid annotating with `dynamic` when not required.",
     "fixStatus": "hasFix"
@@ -102,7 +107,7 @@
   {
     "name": "avoid_final_parameters",
     "description": "Avoid `final` for parameter declarations.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "avoid_function_literals_in_foreach_calls",
@@ -380,6 +385,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "empty_container_bodies",
+    "description": "Use `;` instead of `{}` for empty container bodies.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "empty_statements",
     "description": "Avoid empty statements.",
     "fixStatus": "hasFix"
@@ -430,13 +440,18 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "initialize_in_field_declaration",
+    "description": "Initialize the field in the field's initializer.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "invalid_case_patterns",
     "description": "Use case expressions that are valid in Dart 3.0.",
     "fixStatus": "hasFix"
   },
   {
     "name": "invalid_runtime_check_with_js_interop_types",
-    "description": "Avoid runtime type tests with JS interop types where the result may not\n    be platform-consistent.",
+    "description": "Avoid runtime type tests with JS interop types where the result may not be platform-consistent.",
     "fixStatus": "needsEvaluation"
   },
   {
@@ -525,6 +540,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "no_dynamic_casts",
+    "description": "Avoid implicit casts from `dynamic`.",
+    "fixStatus": "needsFix"
+  },
+  {
     "name": "no_leading_underscores_for_library_prefixes",
     "description": "Avoid leading underscores for library prefixes.",
     "fixStatus": "hasFix"
@@ -545,7 +565,12 @@
     "fixStatus": "noFix"
   },
   {
-    "name": "no_runtimeType_toString",
+    "name": "no_raw_types",
+    "description": "Avoid raw types.",
+    "fixStatus": "needsFix"
+  },
+  {
+    "name": "no_runtimetype_tostring",
     "description": "Avoid calling `toString()` on `runtimeType`.",
     "fixStatus": "noFix"
   },
@@ -865,6 +890,11 @@
     "fixStatus": "noFix"
   },
   {
+    "name": "simple_directive_paths",
+    "description": "Use simple directive paths.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "simplify_variable_pattern",
     "description": "Avoid unnecessary member names in variable patterns.",
     "fixStatus": "hasFix"
@@ -995,6 +1025,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "unnecessary_const_in_enum_constructor",
+    "description": "Don't use an explicit `const` in a generative enum constructor.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "unnecessary_constructor_name",
     "description": "Unnecessary `.new` constructor name.",
     "fixStatus": "hasFix"
@@ -1047,7 +1082,7 @@
   {
     "name": "unnecessary_null_aware_operator_on_extension_on_nullable",
     "description": "Unnecessary null aware operator on extension on a nullable type.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "unnecessary_null_checks",
@@ -1072,6 +1107,11 @@
   {
     "name": "unnecessary_parenthesis",
     "description": "Unnecessary parentheses can be removed.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "unnecessary_primary_constructor_body",
+    "description": "Unnecessary primary constructor bodies can be removed.",
     "fixStatus": "hasFix"
   },
   {
@@ -1105,6 +1145,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "unnecessary_type_name_in_constructor",
+    "description": "Don't use an explicit type name in a constructor.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "unnecessary_unawaited",
     "description": "Unnecessary use of 'unawaited'.",
     "fixStatus": "hasFix"
@@ -1122,7 +1167,7 @@
   {
     "name": "unrelated_type_equality_checks",
     "description": "Equality operator `==` invocation with references of unrelated types.",
-    "fixStatus": "needsEvaluation"
+    "fixStatus": "hasFix"
   },
   {
     "name": "unsafe_html",
@@ -1142,6 +1187,11 @@
   {
     "name": "use_colored_box",
     "description": "Use `ColoredBox`.",
+    "fixStatus": "hasFix"
+  },
+  {
+    "name": "use_declaring_parameters",
+    "description": "Use a declaring parameter.",
     "fixStatus": "hasFix"
   },
   {
@@ -1243,6 +1293,11 @@
     "name": "valid_regexps",
     "description": "Use valid regular expression syntax.",
     "fixStatus": "noFix"
+  },
+  {
+    "name": "var_with_no_type_annotation",
+    "description": "Avoid declaring parameters with `var` and no type annotation.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "void_checks",

--- a/pkgs/lints/tool/rules.json
+++ b/pkgs/lints/tool/rules.json
@@ -420,6 +420,11 @@
     "fixStatus": "hasFix"
   },
   {
+    "name": "future_sync_value",
+    "description": "For synchronous values, `Future.syncValue` is more performant.",
+    "fixStatus": "hasFix"
+  },
+  {
     "name": "hash_and_equals",
     "description": "Always override `hashCode` if overriding `==`.",
     "fixStatus": "hasFix"
@@ -513,6 +518,11 @@
     "name": "matching_super_parameters",
     "description": "Use matching super parameter names.",
     "fixStatus": "needsFix"
+  },
+  {
+    "name": "migrate_design_widgets",
+    "description": "Design widgets should be imported from Material or Cupertino packages.",
+    "fixStatus": "hasFix"
   },
   {
     "name": "missing_code_block_language_in_doc_comment",
@@ -927,7 +937,7 @@
   {
     "name": "sort_pub_dependencies",
     "description": "Sort pub dependencies alphabetically.",
-    "fixStatus": "needsFix"
+    "fixStatus": "hasFix"
   },
   {
     "name": "sort_unnamed_constructors_first",
@@ -1138,6 +1148,11 @@
     "name": "unnecessary_this",
     "description": "Don't access members with `this` unless avoiding shadowing.",
     "fixStatus": "hasFix"
+  },
+  {
+    "name": "unnecessary_this_alias",
+    "description": "Use 'this' directly instead of assigning it to a local variable.",
+    "fixStatus": "needsEvaluation"
   },
   {
     "name": "unnecessary_to_list_in_spreads",


### PR DESCRIPTION
Closes #954
Closes #978

Bump to SDK 3.12.0 to restrict to versions including the new lints.

core:
- switch_on_type

recommended:
- simple_directive_paths
- simplify_variable_pattern
- unnecessary_unawaited
