### PR TITLE
chore(characters): remove unused character and automaton constants

### DIFF
--- a/pkgs/characters/CHANGELOG.md
+++ b/pkgs/characters/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.4.2-wip
+
 ## 1.4.1
 
 * Run `dart format` with the new style.

--- a/pkgs/characters/lib/src/grapheme_clusters/constants.dart
+++ b/pkgs/characters/lib/src/grapheme_clusters/constants.dart
@@ -29,9 +29,6 @@ const int categoryEoT = 18; // End of Text (synthetic input)
 const int categoryCount = categoryEoT + 1;
 const int inputCategoryCount = categoryEoT;
 
-const int regionalIndicatorStart = 0x1F1E6; // A
-const int regionalIndicatorEnd = 0x1F1FF; // Z
-
 // Automaton states for forwards automaton.
 
 /// Bit flag or'ed to the automaton output if there should not be a break
@@ -55,7 +52,6 @@ const int maskState = ~maskFlags;
 // breaks and cursor afterwards.
 const int flagLookaheadBreakNone = flagNoBreak;
 const int flagLookaheadBreakEarly = flagBreak;
-const int flagLookaheadBreakLate = flagLookahead | flagNoBreak; // Not used.
 const int flagLookaheadBreakBoth = flagLookahead | flagBreak;
 
 /// Automaton row length, number of input categories rounded up

--- a/pkgs/characters/pubspec.yaml
+++ b/pkgs/characters/pubspec.yaml
@@ -1,5 +1,5 @@
 name: characters
-version: 1.4.1
+version: 1.4.2-wip
 description: >-
   String replacement with operations that are Unicode/grapheme cluster aware.
 repository: https://github.com/dart-lang/core/tree/main/pkgs/characters


### PR DESCRIPTION
- Remove unused regionalIndicatorStart, regionalIndicatorEnd constants
- Remove unused flagLookaheadBreakLate constant
