### PR TITLE
Mark Context and Style as final

### DIFF
--- a/pkgs/path/CHANGELOG.md
+++ b/pkgs/path/CHANGELOG.md
@@ -7,8 +7,11 @@
   queries and fragments when when normalizing, include them 
   in/as the last segment when splitting.
 - Run `dart format` with the new style.
-- Centralize join logic in `Context` and eliminate redundant validation in `absolute()`.
-- Avoid list allocation in `join()` and `absolute()` argument validation for improved performance.
+- Centralize join logic in `Context` and eliminate redundant validation in
+  `absolute()`.
+- Avoid list allocation in `join()` and `absolute()` argument validation for
+  improved performance.
+- **Potentially breaking** Mark `Context` and `Style` as `final` classes.
 
 ## 1.9.1
 

--- a/pkgs/path/lib/src/context.dart
+++ b/pkgs/path/lib/src/context.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import '../path.dart' as p;
 import 'characters.dart' as chars;
-import 'internal_style.dart';
 import 'parsed_path.dart';
 import 'path_exception.dart';
 import 'style.dart';
@@ -15,7 +14,7 @@ Context createInternal() => Context._internal();
 
 /// An instantiable class for manipulating paths. Unlike the top-level
 /// functions, this lets you explicitly select what platform the paths will use.
-class Context {
+final class Context {
   /// Creates a new path context for the given style and current directory.
   ///
   /// If [style] is omitted, it uses the host operating system's path style. If

--- a/pkgs/path/lib/src/internal_style.dart
+++ b/pkgs/path/lib/src/internal_style.dart
@@ -2,15 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'context.dart';
-import 'style.dart';
+part of 'style.dart';
 
 /// The internal interface for the [Style] type.
 ///
 /// Users should be able to pass around instances of [Style] like an enum, but
 /// the members that [Context] uses should be hidden from them. Those members
 /// are defined on this class instead.
-abstract class InternalStyle extends Style {
+abstract final class InternalStyle extends Style {
   /// The default path separator for this style.
   ///
   /// On POSIX, this is `/`. On Windows, it's `\`.

--- a/pkgs/path/lib/src/parsed_path.dart
+++ b/pkgs/path/lib/src/parsed_path.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'characters.dart' as chars;
-import 'internal_style.dart';
 import 'style.dart';
 import 'utils.dart' show endOfScheme, removeQueryFragment;
 

--- a/pkgs/path/lib/src/style.dart
+++ b/pkgs/path/lib/src/style.dart
@@ -7,7 +7,7 @@ import 'context.dart';
 import 'parsed_path.dart';
 import 'utils.dart';
 
-part  'style/posix.dart';
+part 'style/posix.dart';
 part 'internal_style.dart';
 part 'style/url.dart';
 part 'style/windows.dart';

--- a/pkgs/path/lib/src/style.dart
+++ b/pkgs/path/lib/src/style.dart
@@ -2,13 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'characters.dart' as chars;
 import 'context.dart';
-import 'style/posix.dart';
-import 'style/url.dart';
-import 'style/windows.dart';
+import 'parsed_path.dart';
+import 'utils.dart';
+
+part  'style/posix.dart';
+part 'internal_style.dart';
+part 'style/url.dart';
+part 'style/windows.dart';
 
 /// An enum type describing a "flavor" of path.
-abstract class Style {
+abstract final class Style {
   /// POSIX-style paths use "/" (forward slash) as separators. Absolute paths
   /// start with "/". Used by UNIX, Linux, Mac OS X, and others.
   static final Style posix = PosixStyle();

--- a/pkgs/path/lib/src/style/posix.dart
+++ b/pkgs/path/lib/src/style/posix.dart
@@ -2,12 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../characters.dart' as chars;
-import '../internal_style.dart';
-import '../parsed_path.dart';
+part of '../style.dart';
 
 /// The style for POSIX paths.
-class PosixStyle extends InternalStyle {
+final class PosixStyle extends InternalStyle {
   @override
   final name = 'posix';
   @override

--- a/pkgs/path/lib/src/style/url.dart
+++ b/pkgs/path/lib/src/style/url.dart
@@ -2,12 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../characters.dart' as chars;
-import '../internal_style.dart';
-import '../utils.dart';
+part of '../style.dart';
 
 /// The style for URL paths.
-class UrlStyle extends InternalStyle {
+final class UrlStyle extends InternalStyle {
   @override
   final name = 'url';
   @override

--- a/pkgs/path/lib/src/style/windows.dart
+++ b/pkgs/path/lib/src/style/windows.dart
@@ -2,17 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../characters.dart' as chars;
-import '../internal_style.dart';
-import '../parsed_path.dart';
-import '../utils.dart';
+part of '../style.dart';
 
 // `0b100000` can be bitwise-ORed with uppercase ASCII letters to get their
 // lowercase equivalents.
 const _asciiCaseBit = 0x20;
 
 /// The style for Windows paths.
-class WindowsStyle extends InternalStyle {
+final class WindowsStyle extends InternalStyle {
   @override
   final name = 'windows';
   @override


### PR DESCRIPTION
These classes are not designed for extension outside of the package, and
have never been so. Make this explicit with `final` modifiers on
`Context` and `Style` along with the package-private subtypes of
`Style`.

Some code relies on `style == p.Style.windows` type checks, which work
as long as `Style` is used like an enum as intended. Making the classes
final makes this pattern explicitly safe because the package only allows
for instances where identity based equality matches the semantics.

Switch the style subclass libraries to `part of` files.
