### PR TITLE
Fix doc comment in FixedDateTimeFormatter

### DIFF
--- a/pkgs/convert/lib/src/fixed_datetime_formatter.dart
+++ b/pkgs/convert/lib/src/fixed_datetime_formatter.dart
@@ -5,8 +5,9 @@
 /// A formatter and parser for [DateTime] in a fixed format [String] pattern.
 ///
 /// For example, calling
-/// `FixedDateTimeFormatter('YYYYMMDDhhmmss', isUtc: false).decode('19960425050322')`
-/// has the same result as calling `DateTime(1996, 4, 25, 5, 3, 22)`.
+/// `FixedDateTimeFormatter('YYYYMMDDhhmmss', isUtc: false)`
+/// `.decode('19960425050322')` has the same result as calling
+/// `DateTime(1996, 4, 25, 5, 3, 22)`.
 ///
 /// The allowed characters are
 /// * `Y`	for “calendar year”

--- a/pkgs/convert/lib/src/fixed_datetime_formatter.dart
+++ b/pkgs/convert/lib/src/fixed_datetime_formatter.dart
@@ -5,9 +5,8 @@
 /// A formatter and parser for [DateTime] in a fixed format [String] pattern.
 ///
 /// For example, calling
-/// `FixedDateTimeFormatter('YYYYMMDDhhmmss', isUtc: false)`
-/// `.decode('19960425050322')` has the same result as calling
-/// `DateTime(1996, 4, 25, 5, 3, 22)`.
+/// `FixedDateTimeFormatter('YYYYMMDDhhmmss').decode('19960425050322')` has
+/// the same result as calling `DateTime.utc(1996, 4, 25, 5, 3, 22)`.
 ///
 /// The allowed characters are
 /// * `Y`	for “calendar year”

--- a/pkgs/convert/lib/src/fixed_datetime_formatter.dart
+++ b/pkgs/convert/lib/src/fixed_datetime_formatter.dart
@@ -5,8 +5,8 @@
 /// A formatter and parser for [DateTime] in a fixed format [String] pattern.
 ///
 /// For example, calling
-/// `FixedDateTimeCodec('YYYYMMDDhhmmss').decodeToLocal('19960425050322')` has
-/// the same result as calling `DateTime(1996, 4, 25, 5, 3, 22)`.
+/// `FixedDateTimeFormatter('YYYYMMDDhhmmss', isUtc: false).decode('19960425050322')`
+/// has the same result as calling `DateTime(1996, 4, 25, 5, 3, 22)`.
 ///
 /// The allowed characters are
 /// * `Y`	for “calendar year”


### PR DESCRIPTION
The documentation incorrectly referred to `FixedDateTimeCodec` and called an undefined `decodeToLocal` method. This update corrects the example to use `FixedDateTimeFormatter` with `isUtc: false` and its `decode` method.
