### PR TITLE
chore(lints): promote invalid_runtime_check_with_js_interop_types to core

### DIFF
--- a/pkgs/lints/CHANGELOG.md
+++ b/pkgs/lints/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 - `core`:
   - added [switch_on_type] (https://github.com/dart-lang/core/issues/954)
+  - promoted [invalid_runtime_check_with_js_interop_types] from `recommended`
+    (https://github.com/dart-lang/core/issues/1000)
 - `recommended`:
   - added [simple_directive_paths] (https://github.com/dart-lang/core/issues/978)
   - added [simplify_variable_pattern] (https://github.com/dart-lang/core/issues/954)
   - added [unnecessary_unawaited] (https://github.com/dart-lang/core/issues/954)
 
+[invalid_runtime_check_with_js_interop_types]: https://dart.dev/lints/invalid_runtime_check_with_js_interop_types
 [switch_on_type]: https://dart.dev/lints/switch_on_type
 [simple_directive_paths]: https://dart.dev/lints/simple_directive_paths
 [simplify_variable_pattern]: https://dart.dev/lints/simplify_variable_pattern

--- a/pkgs/lints/lib/core.yaml
+++ b/pkgs/lints/lib/core.yaml
@@ -21,6 +21,7 @@ linter:
     - file_names
     - hash_and_equals
     - implicit_call_tearoffs
+    - invalid_runtime_check_with_js_interop_types
     - library_annotations
     - no_duplicate_case_values
     - no_wildcard_variable_uses

--- a/pkgs/lints/lib/recommended.yaml
+++ b/pkgs/lints/lib/recommended.yaml
@@ -24,7 +24,6 @@ linter:
     - empty_statements
     - exhaustive_cases
     - implementation_imports
-    - invalid_runtime_check_with_js_interop_types
     - library_prefixes
     - library_private_types_in_public_api
     - no_leading_underscores_for_library_prefixes

--- a/pkgs/lints/rules.md
+++ b/pkgs/lints/rules.md
@@ -20,6 +20,7 @@
 | [`file_names`](https://dart.dev/lints/file_names) | Name source files using `lowercase_with_underscores`. |  |
 | [`hash_and_equals`](https://dart.dev/lints/hash_and_equals) | Always override `hashCode` if overriding `==`. | ✅ |
 | [`implicit_call_tearoffs`](https://dart.dev/lints/implicit_call_tearoffs) | Explicitly tear-off `call` methods when using an object as a Function. | ✅ |
+| [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types) | Avoid runtime type tests with JS interop types where the result may not be platform-consistent. |  |
 | [`library_annotations`](https://dart.dev/lints/library_annotations) | Attach library annotations to library directives. | ✅ |
 | [`no_duplicate_case_values`](https://dart.dev/lints/no_duplicate_case_values) | Don't use more than one case with same value. | ✅ |
 | [`no_wildcard_variable_uses`](https://dart.dev/lints/no_wildcard_variable_uses) | Don't use wildcard parameters or variables. |  |
@@ -59,9 +60,8 @@
 | [`control_flow_in_finally`](https://dart.dev/lints/control_flow_in_finally) | Avoid control flow in `finally` blocks. |  |
 | [`empty_constructor_bodies`](https://dart.dev/lints/empty_constructor_bodies) | Use `;` instead of `{}` for empty constructor bodies. | ✅ |
 | [`empty_statements`](https://dart.dev/lints/empty_statements) | Avoid empty statements. | ✅ |
-| [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like classes. | ✅ |
+| [`exhaustive_cases`](https://dart.dev/lints/exhaustive_cases) | Define case clauses for all constants in enum-like types. | ✅ |
 | [`implementation_imports`](https://dart.dev/lints/implementation_imports) | Don't import implementation files from another package. |  |
-| [`invalid_runtime_check_with_js_interop_types`](https://dart.dev/lints/invalid_runtime_check_with_js_interop_types) | Avoid runtime type tests with JS interop types where the result may not be platform-consistent. |  |
 | [`library_prefixes`](https://dart.dev/lints/library_prefixes) | Use `lowercase_with_underscores` when specifying a library prefix. |  |
 | [`library_private_types_in_public_api`](https://dart.dev/lints/library_private_types_in_public_api) | Avoid using private types in public APIs. |  |
 | [`no_leading_underscores_for_library_prefixes`](https://dart.dev/lints/no_leading_underscores_for_library_prefixes) | Avoid leading underscores for library prefixes. | ✅ |

--- a/pkgs/lints/tool/rules.json
+++ b/pkgs/lints/tool/rules.json
@@ -406,7 +406,7 @@
   },
   {
     "name": "exhaustive_cases",
-    "description": "Define case clauses for all constants in enum-like classes.",
+    "description": "Define case clauses for all constants in enum-like types.",
     "fixStatus": "hasFix"
   },
   {


### PR DESCRIPTION
### Rationale

Promote \`invalid_runtime_check_with_js_interop_types\` from \`recommended\` to \`core\` for the upcoming 7.0.0 release.

Invalid runtime type checks on static JS interop types (\`dartVal as JSObject\`, \`jsVal is int\`, \`jsVal is JSString\`) produce runtime \`TypeError\` exceptions under WebAssembly (\`dart2wasm\`). Moving this rule to \`core\` ensures that \`pana\` package scoring docks points for broken JS interop checks before packages are distributed.

### Summary of Changes

- \`pkgs/lints/lib/core.yaml\`: Add \`invalid_runtime_check_with_js_interop_types\`.
- \`pkgs/lints/lib/recommended.yaml\`: Remove \`invalid_runtime_check_with_js_interop_types\` (inherited via \`core.yaml\`).
- \`pkgs/lints/rules.md\`: Regenerated via \`tool/gen_docs.dart\`.
- \`pkgs/lints/tool/rules.json\`: Regenerated via \`tool/gen_docs.dart\`.
- \`pkgs/lints/CHANGELOG.md\`: Document promotion under \`7.0.0-wip\`.

### Verification

- \`dart format --output=none --set-exit-if-changed .\` (clean)
- \`dart analyze --fatal-infos\` (0 issues)
- \`dart tool/validate_lib.dart\` (clean)
- \`dart tool/gen_docs.dart --verify\` (up-to-date)

Fixes #1000
